### PR TITLE
Fix CPU percentage miscalculation

### DIFF
--- a/driver/handle.go
+++ b/driver/handle.go
@@ -113,7 +113,9 @@ func (h *taskHandle) handleStats(ctx context.Context, ch chan *drivers.TaskResou
 						SystemMode: cpuTimes.System * float64(time.Second),
 						UserMode:   cpuTimes.User * float64(time.Second),
 						Measured:   []string{"System Mode", "User Mode"},
-						Percent:    cpuPercent * 100,
+						// CPUPercent already returns a percentage value in the range
+						// [0,100] across all CPUs. Avoid scaling it again.
+						Percent: cpuPercent,
 					},
 				},
 				Timestamp: time.Now().UTC().UnixNano(),


### PR DESCRIPTION
## Summary
- avoid scaling `proc.CPUPercent` result in task stats

## Testing
- `go vet ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68439e4f9830832a90fb75d4a32a7b2a