### PR TITLE
Add basic unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         run: gofmt -w $(git ls-files '*.go')
       - name: Run go vet
         run: go vet ./...
+      - name: Run go test
+        run: go test ./...
       - name: Build darwin arm64 binary
         env:
           GOOS: darwin

--- a/driver/handle_test.go
+++ b/driver/handle_test.go
@@ -1,0 +1,42 @@
+package driver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+func TestTaskHandleTaskStatus(t *testing.T) {
+	t.Parallel()
+	h := &taskHandle{
+		taskConfig: &drivers.TaskConfig{ID: "id", Name: "name"},
+		state:      drivers.TaskStateRunning,
+		pid:        123,
+		startedAt:  time.Now(),
+		exitResult: &drivers.ExitResult{ExitCode: 0},
+	}
+
+	st := h.TaskStatus()
+	if st.ID != "id" || st.Name != "name" {
+		t.Fatalf("unexpected task info: %#v", st)
+	}
+	if st.DriverAttributes["pid"] != "123" {
+		t.Fatalf("unexpected pid attribute: %v", st.DriverAttributes["pid"])
+	}
+	if st.State != drivers.TaskStateRunning {
+		t.Fatalf("unexpected state: %v", st.State)
+	}
+}
+
+func TestTaskHandleIsRunning(t *testing.T) {
+	t.Parallel()
+	h := &taskHandle{state: drivers.TaskStateRunning}
+	if !h.IsRunning() {
+		t.Fatalf("expected running")
+	}
+	h.state = drivers.TaskStateExited
+	if h.IsRunning() {
+		t.Fatalf("expected not running")
+	}
+}

--- a/driver/state_test.go
+++ b/driver/state_test.go
@@ -1,0 +1,23 @@
+package driver
+
+import "testing"
+
+func TestTaskStoreSetGetDelete(t *testing.T) {
+	t.Parallel()
+	ts := newTaskStore()
+	if _, ok := ts.Get("foo"); ok {
+		t.Fatalf("expected no entry for foo")
+	}
+
+	h := &taskHandle{}
+	ts.Set("foo", h)
+
+	if got, ok := ts.Get("foo"); !ok || got != h {
+		t.Fatalf("unexpected handle returned")
+	}
+
+	ts.Delete("foo")
+	if _, ok := ts.Get("foo"); ok {
+		t.Fatalf("expected entry to be deleted")
+	}
+}

--- a/virtualizer/tart_client_test.go
+++ b/virtualizer/tart_client_test.go
@@ -1,0 +1,24 @@
+package virtualizer
+
+import "testing"
+
+func TestConvertTartStatus(t *testing.T) {
+	cases := map[string]VMState{
+		"running": VMStateRunning,
+		"Running": VMStateRunning,
+		"paused":  VMStatePaused,
+		"PAUSED":  VMStatePaused,
+		"stopped": VMStateStopped,
+		"unknown": VMStateStopped,
+	}
+
+	for input, expected := range cases {
+		input := input
+		expected := expected
+		t.Run(input, func(t *testing.T) {
+			if got := convertTartStatus(input); got != expected {
+				t.Fatalf("status %s: expected %s got %s", input, expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- introduce tests for task store behaviors
- test taskHandle status helpers
- validate tart status conversion
- run `go test` in CI

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843abf3c424832a8e14372b34481b9d