### PR TITLE
Add syslog streaming from Tart VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This driver allows Nomad to manage the lifecycle of Tart VMs, providing a way to
 - Task status reporting
 - Signal forwarding to tasks
 - Placeholder for resource usage statistics
+- Syslog streaming from VMs via SSH
 
 ## Requirements
 
@@ -84,10 +85,12 @@ job "example-tart" {
       driver = "tart"
 
       config {
-        url = "ghcr.io/cirruslabs/macos-sequoia-vanilla:latest"
-        name = "example-vm"
-        command = "/bin/echo"
-        args    = ["Hello from Tart VM!"]
+        url          = "ghcr.io/cirruslabs/macos-sequoia-vanilla:latest"
+        name         = "example-vm"
+        ssh_user     = "admin"
+        ssh_password = "changeme"
+        command      = "/bin/echo"
+        args         = ["Hello from Tart VM!"]
       }
 
       resources {

--- a/driver/config.go
+++ b/driver/config.go
@@ -10,10 +10,12 @@ type Config struct {
 
 // TaskConfig is the driver configuration of a task within a job
 type TaskConfig struct {
-	URL     string   `codec:"url"`
-	Name    string   `codec:"name"`
-	Command string   `codec:"command"`
-	Args    []string `codec:"args"`
+	URL         string   `codec:"url"`
+	Name        string   `codec:"name"`
+	Command     string   `codec:"command"`
+	Args        []string `codec:"args"`
+	SSHUser     string   `codec:"ssh_user"`
+	SSHPassword string   `codec:"ssh_password"`
 }
 
 var (
@@ -39,5 +41,10 @@ var (
 			hclspec.NewAttr("args", "list(string)", false),
 			hclspec.NewLiteral(`[]`),
 		),
+		"ssh_user": hclspec.NewDefault(
+			hclspec.NewAttr("ssh_user", "string", false),
+			hclspec.NewLiteral(`"admin"`),
+		),
+		"ssh_password": hclspec.NewAttr("ssh_password", "string", false),
 	})
 )

--- a/driver/handle.go
+++ b/driver/handle.go
@@ -38,6 +38,9 @@ type taskHandle struct {
 	// completedAt is when the task exited
 	completedAt time.Time
 
+	// syslogCancel cancels the syslog streaming goroutine
+	syslogCancel context.CancelFunc
+
 	// exitResult is the result of the task
 	exitResult *drivers.ExitResult
 
@@ -79,6 +82,9 @@ func (h *taskHandle) IsRunning() bool {
 // run waits on the executor and updates the task state when the process exits.
 func (h *taskHandle) run() {
 	defer close(h.doneCh)
+	if h.syslogCancel != nil {
+		defer h.syslogCancel()
+	}
 
 	h.stateLock.Lock()
 	if h.exitResult == nil {

--- a/examples/example.nomad
+++ b/examples/example.nomad
@@ -17,11 +17,22 @@ job "example-tart" {
     task "tart-vm" {
       driver = "tart"
 
+      # Setup password with a secure Nomad var
+      # Example:
+      #   nomad var put nomad/jobs/example-tart ssh_password="your VM password"
+      template {
+        data        = <<EOH
+SSH_PASSWORD={{ with nomadVar "nomad/jobs/example-tart" }}{{ .ssh_password }}{{ end }}
+EOH
+        destination = "secrets/file.env"
+        env         = true
+      }
+
       config {
         url          = "ghcr.io/cirruslabs/macos-sequoia-vanilla:latest"
         name         = "example-vm"
         ssh_user     = "admin"
-        ssh_password = "changeme"
+        ssh_password = "${SSH_PASSWORD}"
         command      = "/bin/echo"
         args         = ["Hello from Tart VM!"]
       }

--- a/examples/example.nomad
+++ b/examples/example.nomad
@@ -18,10 +18,12 @@ job "example-tart" {
       driver = "tart"
 
       config {
-        url = "ghcr.io/cirruslabs/macos-sequoia-vanilla:latest"
-        name = "example-vm"
-        command = "/bin/echo"
-        args    = ["Hello from Tart VM!"]
+        url          = "ghcr.io/cirruslabs/macos-sequoia-vanilla:latest"
+        name         = "example-vm"
+        ssh_user     = "admin"
+        ssh_password = "changeme"
+        command      = "/bin/echo"
+        args         = ["Hello from Tart VM!"]
       }
 
       resources {


### PR DESCRIPTION
## Summary
- stream VM syslog via ssh after launching a VM
- accept ssh password and auto host key checking via sshpass
- add ssh_user and ssh_password fields to task config
- document new options in README and example job

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843b845f4b8832aa2c1f02d64640213