### PR TITLE
Support VM resource configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This driver allows Nomad to manage the lifecycle of Tart VMs, providing a way to
 - Signal forwarding to tasks
 - Placeholder for resource usage statistics
 - Syslog streaming from VMs via SSH
+- Control VM CPU and memory via Nomad's `resources` block
+- Optional VM disk size configuration
 
 ## Requirements
 
@@ -102,11 +104,14 @@ EOH
         # Whether or not to show the built-in Tart UI for the VM
         # Defaults to false
         show_ui      = true
+        # Optional resource configuration for the VM
+        # disk_size is the desired disk size in gigabytes
+        disk_size  = 60
       }
 
       resources {
-        cpu    = 500
-        memory = 256
+        cpu    = 500   # Number of virtual CPU shares (1 core = 1000)
+        memory = 256  # Memory in MB assigned to the VM
       }
 
       logs {

--- a/driver/config.go
+++ b/driver/config.go
@@ -14,6 +14,9 @@ type TaskConfig struct {
 	SSHUser     string `codec:"ssh_user"`
 	SSHPassword string `codec:"ssh_password"`
 	ShowUI      bool   `codec:"show_ui"`
+	// DiskSize is the desired disk size of the VM in gigabytes. Setting this
+	// to zero will leave the disk size unchanged.
+	DiskSize int `codec:"disk_size"`
 }
 
 var (
@@ -33,5 +36,6 @@ var (
 		"ssh_user":     hclspec.NewAttr("ssh_user", "string", true),
 		"ssh_password": hclspec.NewAttr("ssh_password", "string", true),
 		"show_ui":      hclspec.NewDefault(hclspec.NewAttr("show_ui", "bool", false), hclspec.NewLiteral("false")),
+		"disk_size":    hclspec.NewAttr("disk_size", "number", false),
 	})
 )

--- a/examples/example.nomad
+++ b/examples/example.nomad
@@ -38,8 +38,8 @@ EOH
       }
 
       resources {
-        cpu    = 500
-        memory = 256
+        cores = 8
+        memory = 10240 # 10GB
       }
 
       logs {

--- a/virtualizer/virtualizer.go
+++ b/virtualizer/virtualizer.go
@@ -57,4 +57,8 @@ type Virtualizer interface {
 
 	// SSH executes a command on the VM via SSH
 	SSH(ctx context.Context, vmName, user, command string) (string, error)
+
+	// SetVMResources adjusts the CPU cores, memory (in MB), and disk size (in GB)
+	// for the VM. Any value set to zero will be ignored.
+	SetVMResources(ctx context.Context, vmName string, cpu, memoryMB, diskGB int) error
 }


### PR DESCRIPTION
## Summary
- control CPU and memory through the job's `resources` block
- keep optional `disk_size` driver option
- adjust StartTask to apply resources using the Tart `set` command
- document using `resources` for CPU and memory

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684477de2ac0832a8c2f1e5c19b57613