### PR TITLE
Add GoReleaser release setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,9 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      - name: Build darwin arm64 binary
-        env:
-          GOOS: darwin
-          GOARCH: arm64
-        run: go build -o nomad-driver-tart-${GOOS}-${GOARCH} main.go
-      - uses: ncipollo/release-action@v1
+      - uses: goreleaser/goreleaser-action@v5
         with:
-          artifacts: "nomad-driver-tart-darwin-arm64"
-          tag: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,20 @@
+project_name: nomad-driver-tart
+builds:
+  - id: nomad-driver-tart
+    main: ./main.go
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    ldflags: -s -w
+archives:
+  - id: nomad-driver-tart
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+release:
+  github:
+    owner: brianmichel
+    name: nomad-driver-tart

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ This driver is currently in development and provides basic functionality. Future
 
 ### Continuous Integration
 
-A GitHub Actions workflow automatically formats, vets, and builds the driver for darwin/arm64 on every pull request and push to `main`. Tagging a commit with `v*` also uploads the built binary as a release artifact.
+A GitHub Actions workflow automatically formats, vets, and builds the driver for darwin/arm64 on every pull request and push to `main`. When a tag beginning with `v` is pushed, [GoReleaser](https://goreleaser.com/) packages the driver and publishes the release on GitHub.
 
 
 ## License


### PR DESCRIPTION
## Summary
- add GoReleaser configuration
- update CI to run GoReleaser for tagged releases
- document GoReleaser usage in README

## Testing
- `gofmt -w $(git ls-files '*.go')`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847a3bf1478832a8709ed32a97e756d