### PR TITLE
Add optional authentication functionality

### DIFF
--- a/driver/config.go
+++ b/driver/config.go
@@ -16,7 +16,17 @@ type TaskConfig struct {
 	ShowUI      bool   `codec:"show_ui"`
 	// DiskSize is the desired disk size of the VM in gigabytes. Setting this
 	// to zero will leave the disk size unchanged.
-	DiskSize int `codec:"disk_size"`
+	DiskSize int  `codec:"disk_size"`
+	Auth     Auth `codec:"auth"`
+}
+
+type Auth struct {
+	Username string `codec:"username"`
+	Password string `codec:"password"`
+}
+
+func (a Auth) IsValid() bool {
+	return a.Username != "" && a.Password != ""
 }
 
 var (
@@ -37,5 +47,9 @@ var (
 		"ssh_password": hclspec.NewAttr("ssh_password", "string", true),
 		"show_ui":      hclspec.NewDefault(hclspec.NewAttr("show_ui", "bool", false), hclspec.NewLiteral("false")),
 		"disk_size":    hclspec.NewAttr("disk_size", "number", false),
+		"auth": hclspec.NewBlock("auth", true, hclspec.NewObject(map[string]*hclspec.Spec{
+			"username": hclspec.NewAttr("username", "string", true),
+			"password": hclspec.NewAttr("password", "string", true),
+		})),
 	})
 )

--- a/driver/state_test.go
+++ b/driver/state_test.go
@@ -1,23 +1,149 @@
 package driver
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestTaskStoreSetGetDelete(t *testing.T) {
 	t.Parallel()
 	ts := newTaskStore()
-	if _, ok := ts.Get("foo"); ok {
-		t.Fatalf("expected no entry for foo")
+
+	// Test Get on non-existent key
+	if _, ok := ts.Get("nonexistent"); ok {
+		t.Fatalf("expected no entry for nonexistent key")
 	}
 
+	// Test Set and Get
 	h := &taskHandle{}
-	ts.Set("foo", h)
+	ts.Set("test1", h)
 
-	if got, ok := ts.Get("foo"); !ok || got != h {
-		t.Fatalf("unexpected handle returned")
+	// Test Get on existing key
+	got, ok := ts.Get("test1")
+	if !ok || got != h {
+		t.Fatalf("unexpected handle returned, got %v, want %v", got, h)
 	}
 
-	ts.Delete("foo")
-	if _, ok := ts.Get("foo"); ok {
+	// Test overwrite
+	h2 := &taskHandle{}
+	ts.Set("test1", h2)
+	if got, _ := ts.Get("test1"); got != h2 {
+		t.Fatalf("expected handle to be overwritten")
+	}
+
+	// Test Delete
+	ts.Delete("test1")
+	if _, ok := ts.Get("test1"); ok {
 		t.Fatalf("expected entry to be deleted")
+	}
+
+	// Test Delete non-existent key (should not panic)
+	ts.Delete("nonexistent")
+}
+
+func TestTaskStoreConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	ts := newTaskStore()
+	const numRoutines = 100
+	const numKeys = 10
+
+	t.Logf("Starting concurrent test with %d goroutines and %d unique keys", numRoutines, numKeys)
+
+	// Create a wait group to synchronize goroutines
+	var wg sync.WaitGroup
+	
+	// Create a map to track the last handle we expect for each key
+	expectedHandles := make(map[string]*taskHandle)
+	var mu sync.Mutex
+
+	// Start multiple goroutines to set values
+	for i := 0; i < numRoutines; i++ {
+		key := string(rune('A' + (i % numKeys)))
+		h := &taskHandle{}
+
+		// Update our expected handle to be the last one we create for each key
+		mu.Lock()
+		expectedHandles[key] = h
+		mu.Unlock()
+
+		wg.Add(1)
+		go func(k string, handle *taskHandle) {
+			defer wg.Done()
+			ts.Set(k, handle)
+		}(key, h)
+	}
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	t.Log("Verifying all values were set correctly")
+
+	// Verify all values were set correctly
+	for key := range expectedHandles {
+		got, ok := ts.Get(key)
+		if !ok {
+			t.Errorf("key %s was not found in the store", key)
+			continue
+		}
+		// We only care that we got a valid handle, not which one specifically
+		if got == nil {
+			t.Errorf("got nil handle for key %s, expected non-nil", key)
+		}
+	}
+
+	t.Log("Starting concurrent delete operations")
+
+	// Test concurrent deletes
+	for key := range expectedHandles {
+		wg.Add(1)
+		go func(k string) {
+			defer wg.Done()
+			ts.Delete(k)
+		}(key)
+	}
+
+	wg.Wait()
+
+	t.Log("Verifying all values were deleted")
+
+	// Verify all values were deleted
+	for key := range expectedHandles {
+		if _, ok := ts.Get(key); ok {
+			t.Errorf("expected key %s to be deleted but it still exists", key)
+		}
+	}
+
+	t.Log("Concurrent test completed successfully")
+}
+
+func TestTaskStoreNewTaskStore(t *testing.T) {
+	t.Parallel()
+	ts := newTaskStore()
+
+	if ts == nil {
+		t.Fatal("expected newTaskStore to return a non-nil taskStore")
+	}
+
+	if len(ts.store) != 0 {
+		t.Errorf("expected new taskStore to be empty, got %d items", len(ts.store))
+	}
+}
+
+func TestTaskStoreNilHandle(t *testing.T) {
+	t.Parallel()
+	ts := newTaskStore()
+
+	// Test setting nil handle
+	ts.Set("nil-handle", nil)
+
+	got, ok := ts.Get("nil-handle")
+	if !ok || got != nil {
+		t.Errorf("expected nil handle, got %v, ok=%v", got, ok)
+	}
+
+	// Test deleting nil handle
+	ts.Delete("nil-handle")
+	if _, ok := ts.Get("nil-handle"); ok {
+		t.Error("expected nil handle to be deleted")
 	}
 }


### PR DESCRIPTION
If you have private VMs you have to provide a way to authenticate to the container registry in order to pull down the container. This adds a new optional auth block with a username and password property.

If this block is set, and is valid, we will issue the tart login command before we perform the clone operation.