### PR TITLE
Add network configuration for Tart run

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ EOH
         # Optional resource configuration for the VM
         # disk_size is the desired disk size in gigabytes
         disk_size  = 60
+        # Select the network mode for Tart. Supported values: "host", "softnet", etc.
+        network    = "host"
       }
 
       resources {

--- a/driver/config.go
+++ b/driver/config.go
@@ -14,6 +14,9 @@ type TaskConfig struct {
 	SSHUser     string `codec:"ssh_user"`
 	SSHPassword string `codec:"ssh_password"`
 	ShowUI      bool   `codec:"show_ui"`
+	// Network specifies the networking mode used when running the VM. Valid
+	// options include "host", "softnet", etc. Defaults to "host".
+	Network string `codec:"network"`
 	// DiskSize is the desired disk size of the VM in gigabytes. Setting this
 	// to zero will leave the disk size unchanged.
 	DiskSize int  `codec:"disk_size"`
@@ -46,6 +49,7 @@ var (
 		"ssh_user":     hclspec.NewAttr("ssh_user", "string", true),
 		"ssh_password": hclspec.NewAttr("ssh_password", "string", true),
 		"show_ui":      hclspec.NewDefault(hclspec.NewAttr("show_ui", "bool", false), hclspec.NewLiteral("false")),
+		"network":      hclspec.NewDefault(hclspec.NewAttr("network", "string", false), hclspec.NewLiteral("\"host\"")),
 		"disk_size":    hclspec.NewAttr("disk_size", "number", false),
 		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"username": hclspec.NewAttr("username", "string", true),

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -234,6 +234,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	if !taskConfig.ShowUI {
 		args = append(args, "--no-graphics")
 	}
+	if taskConfig.Network != "" {
+		args = append(args, "--net", taskConfig.Network)
+	}
 
 	execCmd := &executor.ExecCommand{
 		Cmd:              "tart",
@@ -244,6 +247,10 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		StdoutPath:       cfg.StdoutPath,
 		StderrPath:       cfg.StderrPath,
 		NetworkIsolation: cfg.NetworkIsolation,
+	}
+
+	if taskConfig.Network == "softnet" {
+		execCmd.User = "root"
 	}
 
 	ps, err := execImpl.Launch(execCmd)

--- a/examples/example.nomad
+++ b/examples/example.nomad
@@ -44,6 +44,8 @@ EOH
         # Whether or not to show the built-in Tart UI for the VM
         # Defaults to false
         show_ui = true
+        # Network mode for Tart VM
+        network = "host"
       }
 
       resources {


### PR DESCRIPTION
## Summary
- expose a `network` option in the task config
- pass the network mode to `tart run`
- force root user when using `softnet`
- document network modes in README and example

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687eceddc450832a93fa8ebafd5914dc