### PR TITLE
Fix registry host login

### DIFF
--- a/driver/registry_host_test.go
+++ b/driver/registry_host_test.go
@@ -1,0 +1,22 @@
+package driver
+
+import "testing"
+
+func TestRegistryHost(t *testing.T) {
+	cases := map[string]string{
+		"708167139547.dkr.ecr.us-east-2.amazonaws.com/ci-runner-macos-sequoia:latest": "708167139547.dkr.ecr.us-east-2.amazonaws.com",
+		"ghcr.io/owner/repo:tag":          "ghcr.io",
+		"https://gcr.io/owner/repo:tag":   "gcr.io",
+		"docker.io/library/ubuntu:latest": "docker.io",
+	}
+
+	for input, expected := range cases {
+		got, err := registryHost(input)
+		if err != nil {
+			t.Fatalf("%s returned error: %v", input, err)
+		}
+		if got != expected {
+			t.Fatalf("expected %s got %s", expected, got)
+		}
+	}
+}

--- a/driver/registry_host_test.go
+++ b/driver/registry_host_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestRegistryHost(t *testing.T) {
 	cases := map[string]string{
-		"708167139547.dkr.ecr.us-east-2.amazonaws.com/ci-runner-macos-sequoia:latest": "708167139547.dkr.ecr.us-east-2.amazonaws.com",
+		"123474567.dkr.ecr.us-east-2.amazonaws.com/testing-container:latest": "123474567.dkr.ecr.us-east-2.amazonaws.com",
 		"ghcr.io/owner/repo:tag":          "ghcr.io",
 		"https://gcr.io/owner/repo:tag":   "gcr.io",
 		"docker.io/library/ubuntu:latest": "docker.io",


### PR DESCRIPTION
## Summary
- fix registry login for images without scheme
- add tests for registryHost helper

## Testing
- `go test ./...` *(fails: unknown field Replace in link.RawAttachProgramOptions)*
- `go vet ./...` *(fails: unknown field Replace in link.RawAttachProgramOptions)*

------
https://chatgpt.com/codex/tasks/task_e_688d3391a438832aa73720e6e19e79c4