### PR TITLE
Add Display Size Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ profile.cov
 # Go workspace file
 go.work
 go.work.sum
+.gocache
 
 # env file
 .env

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ EOH
         # Whether or not to show the built-in Tart UI for the VM
         # Defaults to false
         show_ui      = true
+        # Optional display resolution when UI is visible (width clamped to 800-1920,
+        # height clamped to 600-1080).
+        # display {
+        #   width  = 1280
+        #   height = 720
+        # }
         # Optional resource configuration for the VM
         # disk_size is the desired disk size in gigabytes
         disk_size  = 60

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,11 @@ The following parameters go under the task’s driver config block `task { drive
 
 - `show_ui` (bool, optional, default: `false`): Show Tart’s built-in UI window; when `false` runs headless (`--no-graphics`).
 
+- `display { width, height }` (block, optional): Requested display resolution when the Tart UI is shown.
+  - `width` (number, required): Desired pixel width. Values are clamped to 800–1920.
+  - `height` (number, required): Desired pixel height. Values are clamped to 600–1080.
+  - Applied via `tart set --display <width>x<height>` during setup. Both dimensions must be provided if the block is present.
+
 - `disk_size` (number, optional): Desired VM disk size in gigabytes. `0` leaves disk unchanged.
   - Applied via `tart set --disk-size` during setup.
 

--- a/driver/config.go
+++ b/driver/config.go
@@ -25,6 +25,9 @@ type TaskConfig struct {
 	// Root disk options on how to configure the VM
 	RootDisk *RootDiskOptions `codec:"root_disk"`
 
+	// Display contains resolution settings for the VM UI
+	Display *DisplayConfig `codec:"display"`
+
 	// Directories is a blocklist of host directories to mount into the VM
 	Directories []DirectoryMount `codec:"directory"`
 }
@@ -78,6 +81,11 @@ var (
 			"sync_mode":    hclspec.NewAttr("sync_mode", "string", false),
 		})),
 
+		"display": hclspec.NewBlock("display", false, hclspec.NewObject(map[string]*hclspec.Spec{
+			"width":  hclspec.NewAttr("width", "number", true),
+			"height": hclspec.NewAttr("height", "number", true),
+		})),
+
 		"directory": hclspec.NewBlockList("directory", hclspec.NewObject(map[string]*hclspec.Spec{
 			"name": hclspec.NewAttr("name", "string", true),
 			"path": hclspec.NewAttr("path", "string", true),
@@ -124,4 +132,10 @@ type DirectoryMount struct {
 type DirectoryOptions struct {
 	ReadOnly bool   `codec:"readonly"`
 	Tag      string `codec:"tag"`
+}
+
+// DisplayConfig controls the UI resolution of the VM.
+type DisplayConfig struct {
+	Width  int `codec:"width"`
+	Height int `codec:"height"`
 }

--- a/driver/display.go
+++ b/driver/display.go
@@ -1,0 +1,38 @@
+package driver
+
+import "fmt"
+
+const (
+	minDisplayWidth  = 800
+	maxDisplayWidth  = 1920
+	minDisplayHeight = 600
+	maxDisplayHeight = 1080
+)
+
+func formatDisplayResolution(cfg *DisplayConfig) (string, error) {
+	if cfg == nil {
+		return "", nil
+	}
+
+	if cfg.Width <= 0 {
+		return "", fmt.Errorf("display.width must be greater than zero")
+	}
+	if cfg.Height <= 0 {
+		return "", fmt.Errorf("display.height must be greater than zero")
+	}
+
+	width := clampInt(cfg.Width, minDisplayWidth, maxDisplayWidth)
+	height := clampInt(cfg.Height, minDisplayHeight, maxDisplayHeight)
+
+	return fmt.Sprintf("%dx%d", width, height), nil
+}
+
+func clampInt(value, min, max int) int {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}

--- a/driver/display.go
+++ b/driver/display.go
@@ -4,9 +4,9 @@ import "fmt"
 
 const (
 	minDisplayWidth  = 800
-	maxDisplayWidth  = 1920
+	maxDisplayWidth  = 3840
 	minDisplayHeight = 600
-	maxDisplayHeight = 1080
+	maxDisplayHeight = 2160
 )
 
 func formatDisplayResolution(cfg *DisplayConfig) (string, error) {

--- a/driver/display_test.go
+++ b/driver/display_test.go
@@ -24,12 +24,12 @@ func TestFormatDisplayResolution_WithinBounds(t *testing.T) {
 }
 
 func TestFormatDisplayResolution_ClampBounds(t *testing.T) {
-	cfg := &DisplayConfig{Width: 2560, Height: 1440}
+	cfg := &DisplayConfig{Width: 3900, Height: 3000}
 	res, err := formatDisplayResolution(cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if want := "1920x1080"; res != want {
+	if want := "3840x2160"; res != want {
 		t.Fatalf("got %s, want %s", res, want)
 	}
 }

--- a/driver/display_test.go
+++ b/driver/display_test.go
@@ -1,0 +1,59 @@
+package driver
+
+import "testing"
+
+func TestFormatDisplayResolution_NilConfig(t *testing.T) {
+	res, err := formatDisplayResolution(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != "" {
+		t.Fatalf("expected empty resolution for nil display config, got %q", res)
+	}
+}
+
+func TestFormatDisplayResolution_WithinBounds(t *testing.T) {
+	cfg := &DisplayConfig{Width: 1280, Height: 720}
+	res, err := formatDisplayResolution(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "1280x720"; res != want {
+		t.Fatalf("got %s, want %s", res, want)
+	}
+}
+
+func TestFormatDisplayResolution_ClampBounds(t *testing.T) {
+	cfg := &DisplayConfig{Width: 2560, Height: 1440}
+	res, err := formatDisplayResolution(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "1920x1080"; res != want {
+		t.Fatalf("got %s, want %s", res, want)
+	}
+}
+
+func TestFormatDisplayResolution_LowValuesClamp(t *testing.T) {
+	cfg := &DisplayConfig{Width: 640, Height: 480}
+	res, err := formatDisplayResolution(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "800x600"; res != want {
+		t.Fatalf("got %s, want %s", res, want)
+	}
+}
+
+func TestFormatDisplayResolution_InvalidValues(t *testing.T) {
+	cases := []*DisplayConfig{
+		{Width: 0, Height: 720},
+		{Width: 1280, Height: -1},
+	}
+
+	for i, cfg := range cases {
+		if _, err := formatDisplayResolution(cfg); err == nil {
+			t.Fatalf("case %d: expected error for invalid display values", i)
+		}
+	}
+}

--- a/driver/setup_auth_test.go
+++ b/driver/setup_auth_test.go
@@ -222,6 +222,7 @@ func TestSetup_SetsDisplayResolution(t *testing.T) {
 	vmc := VMConfig{
 		TaskConfig: TaskConfig{
 			URL:     "ghcr.io/example/display:latest",
+			ShowUI:  true,
 			Display: &DisplayConfig{Width: 640, Height: 2000},
 		},
 		NomadConfig: &drivers.TaskConfig{AllocID: "alloc-disp"},
@@ -254,17 +255,81 @@ func TestSetup_SetsDisplayResolution(t *testing.T) {
 	}
 
 	foundDisplay := false
-	for i := 0; i < len(setRec.Args)-1; i++ {
-		if setRec.Args[i] == "--display" {
+	foundNoRefit := false
+	for i := 0; i < len(setRec.Args); i++ {
+		switch setRec.Args[i] {
+		case "--display":
 			foundDisplay = true
+			if i+1 >= len(setRec.Args) {
+				t.Fatalf("--display flag missing value: %v", setRec.Args)
+			}
 			if got, want := setRec.Args[i+1], "800x1080"; got != want {
 				t.Fatalf("display resolution mismatch; got %s want %s", got, want)
 			}
-			break
+		case "--no-display-refit":
+			foundNoRefit = true
 		}
 	}
 	if !foundDisplay {
 		t.Fatalf("--display flag not found in set invocation: %v", setRec.Args)
+	}
+	if !foundNoRefit {
+		t.Fatalf("--no-display-refit flag not found in set invocation: %v", setRec.Args)
+	}
+}
+
+func TestSetup_HeadlessOmitsDisplayRefit(t *testing.T) {
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "cmd.log")
+	t.Setenv("CMD_LOG", logPath)
+
+	orig := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		ha := append([]string{"-test.run=TestHelperProcess", "--", name}, args...)
+		return exec.CommandContext(ctx, os.Args[0], ha...)
+	}
+	defer func() { execCommandContext = orig }()
+
+	vmc := VMConfig{
+		TaskConfig: TaskConfig{
+			URL: "ghcr.io/example/headless:latest",
+			// show_ui defaults to false
+		},
+		NomadConfig: &drivers.TaskConfig{AllocID: "alloc-headless"},
+	}
+
+	c := NewTartClient(testLogger(t))
+	if _, err := c.Setup(context.Background(), vmc); err != nil {
+		t.Fatalf("Setup returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	var setRec *cmdRecord
+	for _, ln := range lines {
+		var r cmdRecord
+		if err := json.Unmarshal([]byte(ln), &r); err != nil {
+			t.Fatalf("parse record: %v", err)
+		}
+		if r.Name == "tart" && len(r.Args) > 0 && r.Args[0] == "set" {
+			rr := r
+			setRec = &rr
+			break
+		}
+	}
+	if setRec == nil {
+		t.Fatalf("expected a set invocation, none found")
+	}
+
+	for _, arg := range setRec.Args {
+		if arg == "--no-display-refit" {
+			t.Fatalf("unexpected --no-display-refit flag in headless setup: %v", setRec.Args)
+		}
 	}
 }
 

--- a/driver/setup_auth_test.go
+++ b/driver/setup_auth_test.go
@@ -223,7 +223,7 @@ func TestSetup_SetsDisplayResolution(t *testing.T) {
 		TaskConfig: TaskConfig{
 			URL:     "ghcr.io/example/display:latest",
 			ShowUI:  true,
-			Display: &DisplayConfig{Width: 640, Height: 2000},
+			Display: &DisplayConfig{Width: 640, Height: 5000},
 		},
 		NomadConfig: &drivers.TaskConfig{AllocID: "alloc-disp"},
 	}
@@ -263,7 +263,7 @@ func TestSetup_SetsDisplayResolution(t *testing.T) {
 			if i+1 >= len(setRec.Args) {
 				t.Fatalf("--display flag missing value: %v", setRec.Args)
 			}
-			if got, want := setRec.Args[i+1], "800x1080"; got != want {
+			if got, want := setRec.Args[i+1], "800x2160"; got != want {
 				t.Fatalf("display resolution mismatch; got %s want %s", got, want)
 			}
 		case "--no-display-refit":

--- a/driver/setup_auth_test.go
+++ b/driver/setup_auth_test.go
@@ -1,223 +1,286 @@
 package driver
 
 import (
-    "context"
-    "encoding/json"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "strings"
-    "testing"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
 
-    "github.com/hashicorp/go-hclog"
-    "github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
 // cmdRecord captures a single executed command invocation for assertions.
 type cmdRecord struct {
-    Name string   `json:"name"`
-    Args []string `json:"args"`
-    Env  []string `json:"env"`
+	Name string   `json:"name"`
+	Args []string `json:"args"`
+	Env  []string `json:"env"`
 }
 
 // TestHelperProcess is invoked as a subprocess to record command invocations.
 // It writes a JSON line with the command/args/env to the file at CMD_LOG.
 func TestHelperProcess(t *testing.T) {
-    if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
-        return
-    }
-    // Find the split marker "--" to extract original command name/args.
-    sep := 0
-    for i, a := range os.Args {
-        if a == "--" {
-            sep = i
-            break
-        }
-    }
-    // Default if not found
-    name := ""
-    var args []string
-    if sep > 0 && sep+1 < len(os.Args) {
-        name = os.Args[sep+1]
-        if sep+2 <= len(os.Args) {
-            args = os.Args[sep+2:]
-        }
-    }
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	// Find the split marker "--" to extract original command name/args.
+	sep := 0
+	for i, a := range os.Args {
+		if a == "--" {
+			sep = i
+			break
+		}
+	}
+	// Default if not found
+	name := ""
+	var args []string
+	if sep > 0 && sep+1 < len(os.Args) {
+		name = os.Args[sep+1]
+		if sep+2 <= len(os.Args) {
+			args = os.Args[sep+2:]
+		}
+	}
 
-    rec := cmdRecord{Name: name, Args: args, Env: os.Environ()}
-    b, _ := json.Marshal(rec)
-    logPath := os.Getenv("CMD_LOG")
-    if logPath != "" {
-        f, _ := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-        if f != nil {
-            defer f.Close()
-            f.Write(append(b, '\n'))
-        }
-    }
-    // Always succeed
-    os.Exit(0)
+	rec := cmdRecord{Name: name, Args: args, Env: os.Environ()}
+	b, _ := json.Marshal(rec)
+	logPath := os.Getenv("CMD_LOG")
+	if logPath != "" {
+		f, _ := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if f != nil {
+			defer f.Close()
+			f.Write(append(b, '\n'))
+		}
+	}
+	// Always succeed
+	os.Exit(0)
 }
 
 // Test that when TaskConfig.Auth is provided, we run tart login with the
 // provided credentials and then tart clone, passing through the environment.
 func TestSetup_UsesTaskAuthAndEnv(t *testing.T) {
-    t.Setenv("GO_WANT_HELPER_PROCESS", "1")
-    t.Setenv("SENTINEL_VAR", "present")
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("SENTINEL_VAR", "present")
 
-    tmp := t.TempDir()
-    logPath := filepath.Join(tmp, "cmd.log")
-    t.Setenv("CMD_LOG", logPath)
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "cmd.log")
+	t.Setenv("CMD_LOG", logPath)
 
-    // Swap the command creator to route invocations to TestHelperProcess.
-    orig := execCommandContext
-    execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-        // Reinvoke the test binary and route to TestHelperProcess
-        ha := append([]string{"-test.run=TestHelperProcess", "--", name}, args...)
-        return exec.CommandContext(ctx, os.Args[0], ha...)
-    }
-    defer func() { execCommandContext = orig }()
+	// Swap the command creator to route invocations to TestHelperProcess.
+	orig := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		// Reinvoke the test binary and route to TestHelperProcess
+		ha := append([]string{"-test.run=TestHelperProcess", "--", name}, args...)
+		return exec.CommandContext(ctx, os.Args[0], ha...)
+	}
+	defer func() { execCommandContext = orig }()
 
-    // Build a VMConfig with concrete TaskConfig.Auth
-    vmc := VMConfig{
-        TaskConfig: TaskConfig{
-            URL: "ghcr.io/example/private:latest",
-            Auth: Auth{Username: "user1", Password: "pass1"},
-        },
-        NomadConfig: &drivers.TaskConfig{AllocID: "alloc-123"},
-    }
+	// Build a VMConfig with concrete TaskConfig.Auth
+	vmc := VMConfig{
+		TaskConfig: TaskConfig{
+			URL:  "ghcr.io/example/private:latest",
+			Auth: Auth{Username: "user1", Password: "pass1"},
+		},
+		NomadConfig: &drivers.TaskConfig{AllocID: "alloc-123"},
+	}
 
-    c := NewTartClient(testLogger(t))
-    if _, err := c.Setup(context.Background(), vmc); err != nil {
-        t.Fatalf("Setup returned error: %v", err)
-    }
+	c := NewTartClient(testLogger(t))
+	if _, err := c.Setup(context.Background(), vmc); err != nil {
+		t.Fatalf("Setup returned error: %v", err)
+	}
 
-    // Read back invocations
-    data, err := os.ReadFile(logPath)
-    if err != nil {
-        t.Fatalf("reading log: %v", err)
-    }
-    lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-    var loginRec, cloneRec *cmdRecord
-    for _, ln := range lines {
-        var r cmdRecord
-        if err := json.Unmarshal([]byte(ln), &r); err != nil {
-            t.Fatalf("parse record: %v", err)
-        }
-        if r.Name == "tart" && len(r.Args) > 0 {
-            if r.Args[0] == "login" && loginRec == nil {
-                rr := r
-                loginRec = &rr
-            }
-            if r.Args[0] == "clone" && cloneRec == nil {
-                rr := r
-                cloneRec = &rr
-            }
-        }
-    }
-    if loginRec == nil {
-        t.Fatalf("expected a login invocation, none found. records: %v", len(lines))
-    }
-    // check username flag present
-    foundUser := false
-    for i := 0; i < len(loginRec.Args)-1; i++ {
-        if loginRec.Args[i] == "--username" && loginRec.Args[i+1] == "user1" {
-            foundUser = true
-            break
-        }
-    }
-    if !foundUser {
-        t.Fatalf("--username user1 not found in login args: %v", loginRec.Args)
-    }
-    // ensure env is passed
-    if !envContains(loginRec.Env, "SENTINEL_VAR", "present") {
-        t.Fatalf("login env missing SENTINEL_VAR=present")
-    }
-    if cloneRec == nil {
-        t.Fatalf("expected a clone invocation, none found")
-    }
-    if !envContains(cloneRec.Env, "SENTINEL_VAR", "present") {
-        t.Fatalf("clone env missing SENTINEL_VAR=present")
-    }
+	// Read back invocations
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	var loginRec, cloneRec *cmdRecord
+	for _, ln := range lines {
+		var r cmdRecord
+		if err := json.Unmarshal([]byte(ln), &r); err != nil {
+			t.Fatalf("parse record: %v", err)
+		}
+		if r.Name == "tart" && len(r.Args) > 0 {
+			if r.Args[0] == "login" && loginRec == nil {
+				rr := r
+				loginRec = &rr
+			}
+			if r.Args[0] == "clone" && cloneRec == nil {
+				rr := r
+				cloneRec = &rr
+			}
+		}
+	}
+	if loginRec == nil {
+		t.Fatalf("expected a login invocation, none found. records: %v", len(lines))
+	}
+	// check username flag present
+	foundUser := false
+	for i := 0; i < len(loginRec.Args)-1; i++ {
+		if loginRec.Args[i] == "--username" && loginRec.Args[i+1] == "user1" {
+			foundUser = true
+			break
+		}
+	}
+	if !foundUser {
+		t.Fatalf("--username user1 not found in login args: %v", loginRec.Args)
+	}
+	// ensure env is passed
+	if !envContains(loginRec.Env, "SENTINEL_VAR", "present") {
+		t.Fatalf("login env missing SENTINEL_VAR=present")
+	}
+	if cloneRec == nil {
+		t.Fatalf("expected a clone invocation, none found")
+	}
+	if !envContains(cloneRec.Env, "SENTINEL_VAR", "present") {
+		t.Fatalf("clone env missing SENTINEL_VAR=present")
+	}
 }
 
 // Test that when TaskConfig.Auth is not valid, we do not run login and rely
 // on env vars, and that env is passed to clone.
 func TestSetup_NoTaskAuth_UsesEnvAndSkipsLogin(t *testing.T) {
-    t.Setenv("GO_WANT_HELPER_PROCESS", "1")
-    t.Setenv("SENTINEL_VAR", "present")
-    t.Setenv("TART_REGISTRY_USER", "envuser")
-    t.Setenv("TART_REGISTRY_PASSWORD", "envpass")
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("SENTINEL_VAR", "present")
+	t.Setenv("TART_REGISTRY_USER", "envuser")
+	t.Setenv("TART_REGISTRY_PASSWORD", "envpass")
 
-    tmp := t.TempDir()
-    logPath := filepath.Join(tmp, "cmd.log")
-    t.Setenv("CMD_LOG", logPath)
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "cmd.log")
+	t.Setenv("CMD_LOG", logPath)
 
-    orig := execCommandContext
-    execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-        ha := append([]string{"-test.run=TestHelperProcess", "--", name}, args...)
-        return exec.CommandContext(ctx, os.Args[0], ha...)
-    }
-    defer func() { execCommandContext = orig }()
+	orig := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		ha := append([]string{"-test.run=TestHelperProcess", "--", name}, args...)
+		return exec.CommandContext(ctx, os.Args[0], ha...)
+	}
+	defer func() { execCommandContext = orig }()
 
-    vmc := VMConfig{
-        TaskConfig: TaskConfig{
-            URL: "ghcr.io/example/private:latest",
-            // No Auth provided
-        },
-        NomadConfig: &drivers.TaskConfig{AllocID: "alloc-abc"},
-    }
+	vmc := VMConfig{
+		TaskConfig: TaskConfig{
+			URL: "ghcr.io/example/private:latest",
+			// No Auth provided
+		},
+		NomadConfig: &drivers.TaskConfig{AllocID: "alloc-abc"},
+	}
 
-    c := NewTartClient(testLogger(t))
-    if _, err := c.Setup(context.Background(), vmc); err != nil {
-        t.Fatalf("Setup returned error: %v", err)
-    }
+	c := NewTartClient(testLogger(t))
+	if _, err := c.Setup(context.Background(), vmc); err != nil {
+		t.Fatalf("Setup returned error: %v", err)
+	}
 
-    data, err := os.ReadFile(logPath)
-    if err != nil {
-        t.Fatalf("reading log: %v", err)
-    }
-    lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-    var sawLogin bool
-    var cloneRec *cmdRecord
-    for _, ln := range lines {
-        var r cmdRecord
-        if err := json.Unmarshal([]byte(ln), &r); err != nil {
-            t.Fatalf("parse record: %v", err)
-        }
-        if r.Name == "tart" && len(r.Args) > 0 {
-            switch r.Args[0] {
-            case "login":
-                sawLogin = true
-            case "clone":
-                rr := r
-                cloneRec = &rr
-            }
-        }
-    }
-    if sawLogin {
-        t.Fatalf("did not expect a login invocation when Auth is not provided")
-    }
-    if cloneRec == nil {
-        t.Fatalf("expected a clone invocation, none found")
-    }
-    if !envContains(cloneRec.Env, "TART_REGISTRY_USER", "envuser") || !envContains(cloneRec.Env, "TART_REGISTRY_PASSWORD", "envpass") {
-        t.Fatalf("clone env missing TART_REGISTRY_* from environment")
-    }
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	var sawLogin bool
+	var cloneRec *cmdRecord
+	for _, ln := range lines {
+		var r cmdRecord
+		if err := json.Unmarshal([]byte(ln), &r); err != nil {
+			t.Fatalf("parse record: %v", err)
+		}
+		if r.Name == "tart" && len(r.Args) > 0 {
+			switch r.Args[0] {
+			case "login":
+				sawLogin = true
+			case "clone":
+				rr := r
+				cloneRec = &rr
+			}
+		}
+	}
+	if sawLogin {
+		t.Fatalf("did not expect a login invocation when Auth is not provided")
+	}
+	if cloneRec == nil {
+		t.Fatalf("expected a clone invocation, none found")
+	}
+	if !envContains(cloneRec.Env, "TART_REGISTRY_USER", "envuser") || !envContains(cloneRec.Env, "TART_REGISTRY_PASSWORD", "envpass") {
+		t.Fatalf("clone env missing TART_REGISTRY_* from environment")
+	}
+}
+
+func TestSetup_SetsDisplayResolution(t *testing.T) {
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "cmd.log")
+	t.Setenv("CMD_LOG", logPath)
+
+	orig := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		ha := append([]string{"-test.run=TestHelperProcess", "--", name}, args...)
+		return exec.CommandContext(ctx, os.Args[0], ha...)
+	}
+	defer func() { execCommandContext = orig }()
+
+	vmc := VMConfig{
+		TaskConfig: TaskConfig{
+			URL:     "ghcr.io/example/display:latest",
+			Display: &DisplayConfig{Width: 640, Height: 2000},
+		},
+		NomadConfig: &drivers.TaskConfig{AllocID: "alloc-disp"},
+	}
+
+	c := NewTartClient(testLogger(t))
+	if _, err := c.Setup(context.Background(), vmc); err != nil {
+		t.Fatalf("Setup returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	var setRec *cmdRecord
+	for _, ln := range lines {
+		var r cmdRecord
+		if err := json.Unmarshal([]byte(ln), &r); err != nil {
+			t.Fatalf("parse record: %v", err)
+		}
+		if r.Name == "tart" && len(r.Args) > 0 && r.Args[0] == "set" {
+			rr := r
+			setRec = &rr
+			break
+		}
+	}
+	if setRec == nil {
+		t.Fatalf("expected a set invocation, none found")
+	}
+
+	foundDisplay := false
+	for i := 0; i < len(setRec.Args)-1; i++ {
+		if setRec.Args[i] == "--display" {
+			foundDisplay = true
+			if got, want := setRec.Args[i+1], "800x1080"; got != want {
+				t.Fatalf("display resolution mismatch; got %s want %s", got, want)
+			}
+			break
+		}
+	}
+	if !foundDisplay {
+		t.Fatalf("--display flag not found in set invocation: %v", setRec.Args)
+	}
 }
 
 // envContains checks for key=value in env slice
 func envContains(env []string, key, val string) bool {
-    want := key + "=" + val
-    for _, e := range env {
-        if e == want {
-            return true
-        }
-    }
-    return false
+	want := key + "=" + val
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
 }
 
 // testLogger returns a no-op logger since TartClient requires one.
 func testLogger(tb testing.TB) hclog.Logger {
-    tb.Helper()
-    return hclog.New(&hclog.LoggerOptions{Level: hclog.Off})
+	tb.Helper()
+	return hclog.New(&hclog.LoggerOptions{Level: hclog.Off})
 }

--- a/driver/tart_client.go
+++ b/driver/tart_client.go
@@ -118,7 +118,7 @@ func (c *TartClient) Setup(ctx context.Context, config VMConfig) (string, error)
 			vmName, url, err, stderr.String())
 	}
 
-	if err := c.SetVMResources(ctx, vmName, cpuCores, memoryMB, diskGB); err != nil {
+	if err := c.SetVMResources(ctx, vmName, cpuCores, memoryMB, diskGB, config.TaskConfig.Display); err != nil {
 		return "", fmt.Errorf("failed to set VM resources: %v", err)
 	}
 
@@ -336,8 +336,8 @@ func (c *TartClient) Exec(ctx context.Context, config VMConfig, opts ExecOptions
 	return 0, nil
 }
 
-// SetVMResources modifies CPU cores, memory (MB), and disk size (GB) for a VM.
-func (c *TartClient) SetVMResources(ctx context.Context, vmName string, cpu, memoryMB, diskGB int) error {
+// SetVMResources modifies CPU cores, memory (MB), disk size (GB), and display resolution for a VM.
+func (c *TartClient) SetVMResources(ctx context.Context, vmName string, cpu, memoryMB, diskGB int, display *DisplayConfig) error {
 	args := []string{"set", vmName}
 	if cpu > 0 {
 		args = append(args, "--cpu", fmt.Sprintf("%d", cpu))
@@ -347,6 +347,15 @@ func (c *TartClient) SetVMResources(ctx context.Context, vmName string, cpu, mem
 	}
 	if diskGB > 0 {
 		args = append(args, "--disk-size", fmt.Sprintf("%d", diskGB))
+	}
+	if display != nil {
+		res, err := formatDisplayResolution(display)
+		if err != nil {
+			return err
+		}
+		if res != "" {
+			args = append(args, "--display", res)
+		}
 	}
 
 	if len(args) == 2 {

--- a/driver/tart_client.go
+++ b/driver/tart_client.go
@@ -118,7 +118,7 @@ func (c *TartClient) Setup(ctx context.Context, config VMConfig) (string, error)
 			vmName, url, err, stderr.String())
 	}
 
-	if err := c.SetVMResources(ctx, vmName, cpuCores, memoryMB, diskGB, config.TaskConfig.Display); err != nil {
+	if err := c.SetVMResources(ctx, vmName, cpuCores, memoryMB, diskGB, config.TaskConfig.Display, config.TaskConfig.ShowUI); err != nil {
 		return "", fmt.Errorf("failed to set VM resources: %v", err)
 	}
 
@@ -336,8 +336,8 @@ func (c *TartClient) Exec(ctx context.Context, config VMConfig, opts ExecOptions
 	return 0, nil
 }
 
-// SetVMResources modifies CPU cores, memory (MB), disk size (GB), and display resolution for a VM.
-func (c *TartClient) SetVMResources(ctx context.Context, vmName string, cpu, memoryMB, diskGB int, display *DisplayConfig) error {
+// SetVMResources modifies CPU cores, memory (MB), disk size (GB), and display settings for a VM.
+func (c *TartClient) SetVMResources(ctx context.Context, vmName string, cpu, memoryMB, diskGB int, display *DisplayConfig, showUI bool) error {
 	args := []string{"set", vmName}
 	if cpu > 0 {
 		args = append(args, "--cpu", fmt.Sprintf("%d", cpu))
@@ -347,6 +347,9 @@ func (c *TartClient) SetVMResources(ctx context.Context, vmName string, cpu, mem
 	}
 	if diskGB > 0 {
 		args = append(args, "--disk-size", fmt.Sprintf("%d", diskGB))
+	}
+	if showUI {
+		args = append(args, "--no-display-refit")
 	}
 	if display != nil {
 		res, err := formatDisplayResolution(display)

--- a/examples/example.nomad.hcl
+++ b/examples/example.nomad.hcl
@@ -44,6 +44,12 @@ EOH
         # Whether or not to show the built-in Tart UI for the VM
         # Defaults to false
         show_ui = true
+        # (optional) Display resolution when UI is shown.
+        # Width is clamped to 800-1920 and height to 600-1080.
+        # display {
+        #   width  = 1280
+        #   height = 720
+        # }
         # (optional) Networking options (mutually exclusive)
         # Default: shared/NAT (no option required)
         # network {


### PR DESCRIPTION
We want to be able to support configuring the display size of the
underlying VM. This can be important in a number of cases such as
running UI tests where people are building with a given resolution in
mind and want that to match on the CI/CD side of things as well.