### PR TITLE
Delete VM when stopping rescheduled tasks

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -339,18 +339,14 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 		return drivers.ErrTaskNotFound
 	}
 
-	allocVMName := d.generateVMName(handle.taskConfig.AllocID)
-
-	// Attempt to gracefully stop the VM via the virtualizer
-	var taskConfig TaskConfig
-	if err := handle.taskConfig.DecodeDriverConfig(&taskConfig); err == nil {
+	var allocVMName string
+	if handle.taskConfig != nil {
+		allocVMName = d.generateVMName(handle.taskConfig.AllocID)
 		if err := d.client.Stop(d.ctx, allocVMName, timeout); err != nil {
-			d.logger.Warn("failed to stop VM via virtualizer", "error", err)
+			d.logger.Warn("failed to stop VM via virtualizer", "task_id", taskID, "error", err)
 		}
-
-		if err := d.client.Delete(d.ctx, allocVMName); err != nil {
-			d.logger.Warn("failed to delete VM via virtualizer", "error", err)
-		}
+	} else {
+		d.logger.Warn("task config missing while stopping task", "task_id", taskID)
 	}
 
 	if err := handle.exec.Shutdown(signal, timeout); err != nil {
@@ -361,7 +357,18 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	}
 
 	<-handle.doneCh
-	handle.pluginClient.Kill()
+
+	if handle.pluginClient != nil {
+		handle.pluginClient.Kill()
+	} else {
+		handle.logger.Warn("plugin client missing while stopping task")
+	}
+
+	if allocVMName != "" {
+		if err := d.client.Delete(d.ctx, allocVMName); err != nil {
+			d.logger.Warn("failed to delete VM via virtualizer", "task_id", taskID, "error", err)
+		}
+	}
 
 	d.logger.Info("stopped tart task", "task_id", taskID)
 	return nil
@@ -378,11 +385,24 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 		return fmt.Errorf("cannot destroy running task")
 	}
 
-	if !handle.pluginClient.Exited() {
-		if err := handle.exec.Shutdown("", 0); err != nil {
-			handle.logger.Error("destroying executor failed", "error", err)
+	if handle.pluginClient != nil && !handle.pluginClient.Exited() {
+		if handle.exec != nil {
+			if err := handle.exec.Shutdown("", 0); err != nil {
+				handle.logger.Error("destroying executor failed", "error", err)
+			}
+		} else {
+			handle.logger.Warn("executor missing while destroying task")
 		}
 		handle.pluginClient.Kill()
+	}
+
+	if handle.taskConfig != nil {
+		allocVMName := d.generateVMName(handle.taskConfig.AllocID)
+		if err := d.client.Delete(d.ctx, allocVMName); err != nil {
+			d.logger.Warn("failed to delete VM via virtualizer", "task_id", taskID, "error", err)
+		}
+	} else {
+		d.logger.Warn("task config missing while destroying task", "task_id", taskID)
 	}
 
 	d.tasks.Delete(taskID)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1,0 +1,154 @@
+package driver
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/drivers/shared/executor"
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+type mockVirtualizer struct {
+	deleteCalled bool
+	deleteName   string
+	stopCalled   bool
+	stopName     string
+}
+
+func (m *mockVirtualizer) Available(context.Context) (string, error)        { return "", nil }
+func (m *mockVirtualizer) Setup(context.Context, VMConfig) (string, error)  { return "", nil }
+func (m *mockVirtualizer) Start(context.Context, string, bool) (int, error) { return 0, nil }
+func (m *mockVirtualizer) Stop(_ context.Context, vmName string, _ time.Duration) error {
+	m.stopCalled = true
+	m.stopName = vmName
+	return nil
+}
+func (m *mockVirtualizer) Status(context.Context, string) (VMState, error) {
+	return VMStateStopped, nil
+}
+func (m *mockVirtualizer) Delete(_ context.Context, vmName string) error {
+	m.deleteCalled = true
+	m.deleteName = vmName
+	return nil
+}
+func (m *mockVirtualizer) List(context.Context) ([]VMInfo, error)                   { return nil, nil }
+func (m *mockVirtualizer) Exec(context.Context, VMConfig, ExecOptions) (int, error) { return 0, nil }
+func (m *mockVirtualizer) BuildStartArgs(VMConfig) ([]string, error)                { return nil, nil }
+func (m *mockVirtualizer) NeedsImageDownload(context.Context, VMConfig) (bool, error) {
+	return false, nil
+}
+
+type stubExecutor struct {
+	shutdownCalled bool
+	shutdownSignal string
+	shutdownAfter  time.Duration
+}
+
+func (s *stubExecutor) Launch(*executor.ExecCommand) (*executor.ProcessState, error) { return nil, nil }
+func (s *stubExecutor) Wait(context.Context) (*executor.ProcessState, error)         { return nil, nil }
+func (s *stubExecutor) Shutdown(signal string, gracePeriod time.Duration) error {
+	s.shutdownCalled = true
+	s.shutdownSignal = signal
+	s.shutdownAfter = gracePeriod
+	return nil
+}
+func (s *stubExecutor) UpdateResources(*drivers.Resources) error { return nil }
+func (s *stubExecutor) Version() (*executor.ExecutorVersion, error) {
+	return &executor.ExecutorVersion{}, nil
+}
+func (s *stubExecutor) Stats(context.Context, time.Duration) (<-chan *cstructs.TaskResourceUsage, error) {
+	return nil, nil
+}
+func (s *stubExecutor) Signal(os.Signal) error { return nil }
+func (s *stubExecutor) Exec(time.Time, string, []string) ([]byte, int, error) {
+	return nil, 0, nil
+}
+func (s *stubExecutor) ExecStreaming(context.Context, []string, bool, drivers.ExecTaskStream) error {
+	return nil
+}
+
+func TestStopTaskDeletesVM(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	drv := NewTartDriver(logger).(*Driver)
+
+	mock := &mockVirtualizer{}
+	drv.client = mock
+
+	exec := &stubExecutor{}
+	doneCh := make(chan struct{})
+	close(doneCh)
+
+	taskID := "task-stop"
+	allocID := "alloc-stop"
+	drv.tasks.Set(taskID, &taskHandle{
+		taskConfig: &drivers.TaskConfig{
+			ID:      taskID,
+			Name:    "test-stop",
+			AllocID: allocID,
+		},
+		state:        drivers.TaskStateRunning,
+		exec:         exec,
+		pluginClient: nil,
+		doneCh:       doneCh,
+		logger:       drv.logger,
+	})
+
+	if err := drv.StopTask(taskID, time.Second, "SIGINT"); err != nil {
+		t.Fatalf("StopTask returned error: %v", err)
+	}
+
+	if !exec.shutdownCalled {
+		t.Fatal("expected executor Shutdown to be called")
+	}
+
+	expectedName := drv.generateVMName(allocID)
+
+	if !mock.stopCalled || mock.stopName != expectedName {
+		t.Fatalf("expected Stop to be called with %q", expectedName)
+	}
+
+	if !mock.deleteCalled || mock.deleteName != expectedName {
+		t.Fatalf("expected Delete to be called with %q", expectedName)
+	}
+}
+
+func TestDestroyTaskDeletesVM(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	drv := NewTartDriver(logger).(*Driver)
+
+	mock := &mockVirtualizer{}
+	drv.client = mock
+
+	taskID := "task-123"
+	allocID := "alloc-abc"
+	drv.tasks.Set(taskID, &taskHandle{
+		taskConfig: &drivers.TaskConfig{
+			ID:      taskID,
+			Name:    "test",
+			AllocID: allocID,
+		},
+		state:  drivers.TaskStateExited,
+		logger: drv.logger,
+	})
+
+	if err := drv.DestroyTask(taskID, false); err != nil {
+		t.Fatalf("DestroyTask returned error: %v", err)
+	}
+
+	if !mock.deleteCalled {
+		t.Fatalf("expected Delete to be called on the virtualizer")
+	}
+
+	expectedName := drv.generateVMName(allocID)
+	if mock.deleteName != expectedName {
+		t.Fatalf("expected Delete to be called with %q, got %q", expectedName, mock.deleteName)
+	}
+
+	if _, ok := drv.tasks.Get(taskID); ok {
+		t.Fatalf("expected task %q to be removed from store", taskID)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure Tart VMs are deleted when StopTask runs so rescheduled allocations do not leave disks behind
- guard StopTask teardown when the plugin client is unavailable and emit task-scoped warnings
- add unit coverage for StopTask invoking virtualizer Stop/Delete alongside the existing DestroyTask check

## Testing
- `go test ./driver` *(hangs with no output; interrupted after waiting for completion)*

------
https://chatgpt.com/codex/tasks/task_e_6909091daa68832abb5fb3d3b9ac3c75