### PR TITLE
Add prewarm boolean to fetch an image.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,12 +33,12 @@ The following parameters go under the task’s driver config block `task { drive
 - `url` (string, required): Tart image reference to clone (e.g. `ghcr.io/cirruslabs/macos-sequoia-base:latest`).
   - Used to `tart clone` the VM before start.
 
-- `ssh_user` (string, required unless `prewarm = true`): Username the driver uses to SSH into the VM for logs/exec.
+- `ssh_user` (string, required unless `pull_only = true`): Username the driver uses to SSH into the VM for logs/exec.
 
-- `ssh_password` (string, required unless `prewarm = true`): Password used for SSH.
+- `ssh_password` (string, required unless `pull_only = true`): Password used for SSH.
   - Tip: inject via Nomad template and var, not hard-coded.
 
-- `prewarm` (bool, optional, default: `false`): When true, the task runs `tart pull <url>` on the client to populate the local image cache and exits — no VM is created, started, or deleted. Typically scheduled as a `sysbatch` job with a client constraint so every selected client pre-fetches the image ahead of real workload tasks. See `examples/prewarm.nomad.hcl`.
+- `pull_only` (bool, optional, default: `false`): When true, the task runs `tart pull <url>` on the client to populate the local image cache and exits — no VM is created, started, or deleted. Typically scheduled as a `sysbatch` job with a client constraint to pre-warm a fleet ahead of real workload tasks. See `examples/prewarm.nomad.hcl`.
 
 - `show_ui` (bool, optional, default: `false`): Show Tart’s built-in UI window; when `false` runs headless (`--no-graphics`).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,10 +33,12 @@ The following parameters go under the task’s driver config block `task { drive
 - `url` (string, required): Tart image reference to clone (e.g. `ghcr.io/cirruslabs/macos-sequoia-base:latest`).
   - Used to `tart clone` the VM before start.
 
-- `ssh_user` (string, required): Username the driver uses to SSH into the VM for logs/exec.
+- `ssh_user` (string, required unless `prewarm = true`): Username the driver uses to SSH into the VM for logs/exec.
 
-- `ssh_password` (string, required): Password used for SSH.
+- `ssh_password` (string, required unless `prewarm = true`): Password used for SSH.
   - Tip: inject via Nomad template and var, not hard-coded.
+
+- `prewarm` (bool, optional, default: `false`): When true, the task runs `tart pull <url>` on the client to populate the local image cache and exits — no VM is created, started, or deleted. Typically scheduled as a `sysbatch` job with a client constraint so every selected client pre-fetches the image ahead of real workload tasks. See `examples/prewarm.nomad.hcl`.
 
 - `show_ui` (bool, optional, default: `false`): Show Tart’s built-in UI window; when `false` runs headless (`--no-graphics`).
 

--- a/driver/config.go
+++ b/driver/config.go
@@ -19,6 +19,12 @@ type TaskConfig struct {
 	DiskSize int  `codec:"disk_size"`
 	Auth     Auth `codec:"auth"`
 
+	// Prewarm, when true, turns the task into a short-lived image prefetch:
+	// the driver runs `tart pull <url>` on the client to populate the local
+	// OCI cache and then exits. No VM is created, started, or deleted.
+	// Typically scheduled as a sysbatch job with a client constraint.
+	Prewarm bool `codec:"prewarm"`
+
 	// Network contains networking options for the VM
 	Network *NetworkConfig `codec:"network"`
 
@@ -51,11 +57,15 @@ var (
 	// taskConfigSpec is the hcl specification for the driver config section of
 	// a task within a job. It is returned in the TaskConfigSchema RPC
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
-		"url":          hclspec.NewAttr("url", "string", true),
-		"ssh_user":     hclspec.NewAttr("ssh_user", "string", true),
-		"ssh_password": hclspec.NewAttr("ssh_password", "string", true),
+		"url": hclspec.NewAttr("url", "string", true),
+		// ssh_user / ssh_password are required for normal (VM-running) tasks
+		// but not for prewarm-only tasks; this is enforced in the driver at
+		// StartTask time rather than by the schema.
+		"ssh_user":     hclspec.NewAttr("ssh_user", "string", false),
+		"ssh_password": hclspec.NewAttr("ssh_password", "string", false),
 		"show_ui":      hclspec.NewDefault(hclspec.NewAttr("show_ui", "bool", false), hclspec.NewLiteral("false")),
 		"disk_size":    hclspec.NewAttr("disk_size", "number", false),
+		"prewarm":      hclspec.NewDefault(hclspec.NewAttr("prewarm", "bool", false), hclspec.NewLiteral("false")),
 		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"username": hclspec.NewAttr("username", "string", true),
 			"password": hclspec.NewAttr("password", "string", true),

--- a/driver/config.go
+++ b/driver/config.go
@@ -19,11 +19,12 @@ type TaskConfig struct {
 	DiskSize int  `codec:"disk_size"`
 	Auth     Auth `codec:"auth"`
 
-	// Prewarm, when true, turns the task into a short-lived image prefetch:
+	// PullOnly, when true, turns the task into a short-lived image prefetch:
 	// the driver runs `tart pull <url>` on the client to populate the local
 	// OCI cache and then exits. No VM is created, started, or deleted.
-	// Typically scheduled as a sysbatch job with a client constraint.
-	Prewarm bool `codec:"prewarm"`
+	// Typically scheduled as a sysbatch job with a client constraint to
+	// pre-warm a fleet of Nomad clients.
+	PullOnly bool `codec:"pull_only"`
 
 	// Network contains networking options for the VM
 	Network *NetworkConfig `codec:"network"`
@@ -59,13 +60,13 @@ var (
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		"url": hclspec.NewAttr("url", "string", true),
 		// ssh_user / ssh_password are required for normal (VM-running) tasks
-		// but not for prewarm-only tasks; this is enforced in the driver at
+		// but not for pull_only tasks; this is enforced in the driver at
 		// StartTask time rather than by the schema.
 		"ssh_user":     hclspec.NewAttr("ssh_user", "string", false),
 		"ssh_password": hclspec.NewAttr("ssh_password", "string", false),
 		"show_ui":      hclspec.NewDefault(hclspec.NewAttr("show_ui", "bool", false), hclspec.NewLiteral("false")),
 		"disk_size":    hclspec.NewAttr("disk_size", "number", false),
-		"prewarm":      hclspec.NewDefault(hclspec.NewAttr("prewarm", "bool", false), hclspec.NewLiteral("false")),
+		"pull_only":    hclspec.NewDefault(hclspec.NewAttr("pull_only", "bool", false), hclspec.NewLiteral("false")),
 		"auth": hclspec.NewBlock("auth", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"username": hclspec.NewAttr("username", "string", true),
 			"password": hclspec.NewAttr("password", "string", true),

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -84,7 +84,7 @@ type TaskState struct {
 	StartedAt   time.Time
 	CompletedAt time.Time
 	ExitResult  *drivers.ExitResult
-	Prewarm     bool
+	PullOnly    bool
 }
 
 // NewTartDriver returns a new driver plugin implementation
@@ -171,12 +171,12 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		NomadConfig: cfg,
 	}
 
-	if taskConfig.Prewarm {
-		return d.startPrewarmTask(cfg, vmConfig, handle)
+	if taskConfig.PullOnly {
+		return d.startPullOnlyTask(cfg, vmConfig, handle)
 	}
 
 	if taskConfig.SSHUser == "" || taskConfig.SSHPassword == "" {
-		return nil, nil, fmt.Errorf("ssh_user and ssh_password are required unless prewarm = true")
+		return nil, nil, fmt.Errorf("ssh_user and ssh_password are required unless pull_only = true")
 	}
 
 	needsDownload, err := d.client.NeedsImageDownload(d.ctx, vmConfig)
@@ -304,11 +304,11 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	return handle, nil, nil
 }
 
-// startPrewarmTask runs `tart pull <url>` via the executor so that the image
+// startPullOnlyTask runs `tart pull <url>` via the executor so that the image
 // is cached locally on the Nomad client. No VM is created; the task
 // completes as soon as the pull exits.
-func (d *Driver) startPrewarmTask(cfg *drivers.TaskConfig, vmConfig VMConfig, handle *drivers.TaskHandle) (*drivers.TaskHandle, *drivers.DriverNetwork, error) {
-	d.logger.Info("starting tart prewarm task", "url", vmConfig.TaskConfig.URL)
+func (d *Driver) startPullOnlyTask(cfg *drivers.TaskConfig, vmConfig VMConfig, handle *drivers.TaskHandle) (*drivers.TaskHandle, *drivers.DriverNetwork, error) {
+	d.logger.Info("starting tart pull-only task", "url", vmConfig.TaskConfig.URL)
 
 	if _, err := d.client.PrepareRegistryEnv(d.ctx, vmConfig); err != nil {
 		return nil, nil, fmt.Errorf("failed to prepare registry env: %v", err)
@@ -319,7 +319,7 @@ func (d *Driver) startPrewarmTask(cfg *drivers.TaskConfig, vmConfig VMConfig, ha
 		TaskName:  cfg.Name,
 		AllocID:   cfg.AllocID,
 		Timestamp: time.Now(),
-		Message:   "Prewarming VM image",
+		Message:   "Pulling VM image",
 		Annotations: map[string]string{
 			"url": vmConfig.TaskConfig.URL,
 		},
@@ -339,7 +339,7 @@ func (d *Driver) startPrewarmTask(cfg *drivers.TaskConfig, vmConfig VMConfig, ha
 
 	execCmd := &executor.ExecCommand{
 		Cmd:              "tart",
-		Args:             d.client.BuildPrewarmArgs(vmConfig),
+		Args:             d.client.BuildPullArgs(vmConfig),
 		Env:              d.TartEnvList(cfg),
 		User:             cfg.User,
 		TaskDir:          cfg.TaskDir().Dir,
@@ -351,13 +351,13 @@ func (d *Driver) startPrewarmTask(cfg *drivers.TaskConfig, vmConfig VMConfig, ha
 	ps, err := execImpl.Launch(execCmd)
 	if err != nil {
 		pluginClient.Kill()
-		return nil, nil, fmt.Errorf("failed to launch prewarm: %v", err)
+		return nil, nil, fmt.Errorf("failed to launch pull: %v", err)
 	}
 
 	state := TaskState{
 		TaskConfig: cfg,
 		StartedAt:  time.Now(),
-		Prewarm:    true,
+		PullOnly:   true,
 	}
 	handle.State = drivers.TaskStateRunning
 	if err := handle.SetDriverState(&state); err != nil {
@@ -375,7 +375,7 @@ func (d *Driver) startPrewarmTask(cfg *drivers.TaskConfig, vmConfig VMConfig, ha
 		startedAt:    time.Now().Round(time.Millisecond),
 		logger:       d.logger,
 		doneCh:       make(chan struct{}),
-		prewarm:      true,
+		pullOnly:     true,
 	}
 
 	d.tasks.Set(cfg.ID, h)
@@ -429,7 +429,7 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	}
 
 	var allocVMName string
-	if handle.taskConfig != nil && !handle.prewarm {
+	if handle.taskConfig != nil && !handle.pullOnly {
 		allocVMName = d.generateVMName(handle.taskConfig.AllocID)
 		if err := d.client.Stop(d.ctx, allocVMName, timeout); err != nil {
 			d.logger.Warn("failed to stop VM via virtualizer", "task_id", taskID, "error", err)
@@ -485,7 +485,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 		handle.pluginClient.Kill()
 	}
 
-	if handle.taskConfig != nil && !handle.prewarm {
+	if handle.taskConfig != nil && !handle.pullOnly {
 		allocVMName := d.generateVMName(handle.taskConfig.AllocID)
 		if err := d.client.Delete(d.ctx, allocVMName); err != nil {
 			d.logger.Warn("failed to delete VM via virtualizer", "task_id", taskID, "error", err)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -33,7 +33,7 @@ var (
 	pluginInfo = &base.PluginInfoResponse{
 		Type:              base.PluginTypeDriver,
 		PluginApiVersions: []string{drivers.ApiVersion010},
-		PluginVersion:     "0.1.0",
+		PluginVersion:     "0.2.0",
 		Name:              pluginName,
 	}
 
@@ -84,6 +84,7 @@ type TaskState struct {
 	StartedAt   time.Time
 	CompletedAt time.Time
 	ExitResult  *drivers.ExitResult
+	Prewarm     bool
 }
 
 // NewTartDriver returns a new driver plugin implementation
@@ -168,6 +169,14 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	vmConfig := VMConfig{
 		TaskConfig:  taskConfig,
 		NomadConfig: cfg,
+	}
+
+	if taskConfig.Prewarm {
+		return d.startPrewarmTask(cfg, vmConfig, handle)
+	}
+
+	if taskConfig.SSHUser == "" || taskConfig.SSHPassword == "" {
+		return nil, nil, fmt.Errorf("ssh_user and ssh_password are required unless prewarm = true")
 	}
 
 	needsDownload, err := d.client.NeedsImageDownload(d.ctx, vmConfig)
@@ -295,6 +304,86 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	return handle, nil, nil
 }
 
+// startPrewarmTask runs `tart pull <url>` via the executor so that the image
+// is cached locally on the Nomad client. No VM is created; the task
+// completes as soon as the pull exits.
+func (d *Driver) startPrewarmTask(cfg *drivers.TaskConfig, vmConfig VMConfig, handle *drivers.TaskHandle) (*drivers.TaskHandle, *drivers.DriverNetwork, error) {
+	d.logger.Info("starting tart prewarm task", "url", vmConfig.TaskConfig.URL)
+
+	if _, err := d.client.PrepareRegistryEnv(d.ctx, vmConfig); err != nil {
+		return nil, nil, fmt.Errorf("failed to prepare registry env: %v", err)
+	}
+
+	d.eventer.EmitEvent(&drivers.TaskEvent{
+		TaskID:    cfg.ID,
+		TaskName:  cfg.Name,
+		AllocID:   cfg.AllocID,
+		Timestamp: time.Now(),
+		Message:   "Prewarming VM image",
+		Annotations: map[string]string{
+			"url": vmConfig.TaskConfig.URL,
+		},
+	})
+
+	pluginLogFile := filepath.Join(cfg.TaskDir().Dir, "executor.out")
+	execConfig := &executor.ExecutorConfig{
+		LogFile:  pluginLogFile,
+		LogLevel: "debug",
+	}
+
+	logger := d.logger.With("task_name", handle.Config.Name, "alloc_id", handle.Config.AllocID)
+	execImpl, pluginClient, err := executor.CreateExecutor(logger, d.nomadConfig, execConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create executor: %v", err)
+	}
+
+	execCmd := &executor.ExecCommand{
+		Cmd:              "tart",
+		Args:             d.client.BuildPrewarmArgs(vmConfig),
+		Env:              d.TartEnvList(cfg),
+		User:             cfg.User,
+		TaskDir:          cfg.TaskDir().Dir,
+		StdoutPath:       cfg.StdoutPath,
+		StderrPath:       cfg.StderrPath,
+		NetworkIsolation: cfg.NetworkIsolation,
+	}
+
+	ps, err := execImpl.Launch(execCmd)
+	if err != nil {
+		pluginClient.Kill()
+		return nil, nil, fmt.Errorf("failed to launch prewarm: %v", err)
+	}
+
+	state := TaskState{
+		TaskConfig: cfg,
+		StartedAt:  time.Now(),
+		Prewarm:    true,
+	}
+	handle.State = drivers.TaskStateRunning
+	if err := handle.SetDriverState(&state); err != nil {
+		execImpl.Shutdown("", 0)
+		pluginClient.Kill()
+		return nil, nil, fmt.Errorf("failed to set driver state: %v", err)
+	}
+
+	h := &taskHandle{
+		exec:         execImpl,
+		pluginClient: pluginClient,
+		pid:          ps.Pid,
+		taskConfig:   cfg,
+		state:        drivers.TaskStateRunning,
+		startedAt:    time.Now().Round(time.Millisecond),
+		logger:       d.logger,
+		doneCh:       make(chan struct{}),
+		prewarm:      true,
+	}
+
+	d.tasks.Set(cfg.ID, h)
+	go h.run()
+
+	return handle, nil, nil
+}
+
 // RecoverTask recreates the in-memory state of a task from a TaskHandle.
 func (d *Driver) RecoverTask(h *drivers.TaskHandle) error {
 	if h == nil {
@@ -340,12 +429,12 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	}
 
 	var allocVMName string
-	if handle.taskConfig != nil {
+	if handle.taskConfig != nil && !handle.prewarm {
 		allocVMName = d.generateVMName(handle.taskConfig.AllocID)
 		if err := d.client.Stop(d.ctx, allocVMName, timeout); err != nil {
 			d.logger.Warn("failed to stop VM via virtualizer", "task_id", taskID, "error", err)
 		}
-	} else {
+	} else if handle.taskConfig == nil {
 		d.logger.Warn("task config missing while stopping task", "task_id", taskID)
 	}
 
@@ -396,12 +485,12 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 		handle.pluginClient.Kill()
 	}
 
-	if handle.taskConfig != nil {
+	if handle.taskConfig != nil && !handle.prewarm {
 		allocVMName := d.generateVMName(handle.taskConfig.AllocID)
 		if err := d.client.Delete(d.ctx, allocVMName); err != nil {
 			d.logger.Warn("failed to delete VM via virtualizer", "task_id", taskID, "error", err)
 		}
-	} else {
+	} else if handle.taskConfig == nil {
 		d.logger.Warn("task config missing while destroying task", "task_id", taskID)
 	}
 

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -44,7 +44,7 @@ func (m *mockVirtualizer) NeedsImageDownload(context.Context, VMConfig) (bool, e
 func (m *mockVirtualizer) PrepareRegistryEnv(context.Context, VMConfig) ([]string, error) {
 	return nil, nil
 }
-func (m *mockVirtualizer) BuildPrewarmArgs(VMConfig) []string { return nil }
+func (m *mockVirtualizer) BuildPullArgs(VMConfig) []string { return nil }
 
 type stubExecutor struct {
 	shutdownCalled bool
@@ -120,7 +120,7 @@ func TestStopTaskDeletesVM(t *testing.T) {
 	}
 }
 
-func TestStopTaskPrewarmSkipsVMOps(t *testing.T) {
+func TestStopTaskPullOnlySkipsVMOps(t *testing.T) {
 	logger := hclog.NewNullLogger()
 	drv := NewTartDriver(logger).(*Driver)
 
@@ -131,58 +131,58 @@ func TestStopTaskPrewarmSkipsVMOps(t *testing.T) {
 	doneCh := make(chan struct{})
 	close(doneCh)
 
-	taskID := "task-prewarm-stop"
+	taskID := "task-pull-only-stop"
 	drv.tasks.Set(taskID, &taskHandle{
 		taskConfig: &drivers.TaskConfig{
 			ID:      taskID,
-			Name:    "test-prewarm-stop",
-			AllocID: "alloc-prewarm-stop",
+			Name:    "test-pull-only-stop",
+			AllocID: "alloc-pull-only-stop",
 		},
-		state:   drivers.TaskStateRunning,
-		exec:    exec,
-		doneCh:  doneCh,
-		logger:  drv.logger,
-		prewarm: true,
+		state:    drivers.TaskStateRunning,
+		exec:     exec,
+		doneCh:   doneCh,
+		logger:   drv.logger,
+		pullOnly: true,
 	})
 
 	if err := drv.StopTask(taskID, time.Second, "SIGINT"); err != nil {
 		t.Fatalf("StopTask returned error: %v", err)
 	}
 	if mock.stopCalled {
-		t.Fatal("expected virtualizer Stop to NOT be called for a prewarm task")
+		t.Fatal("expected virtualizer Stop to NOT be called for a pull_only task")
 	}
 	if mock.deleteCalled {
-		t.Fatal("expected virtualizer Delete to NOT be called for a prewarm task")
+		t.Fatal("expected virtualizer Delete to NOT be called for a pull_only task")
 	}
 	if !exec.shutdownCalled {
-		t.Fatal("expected executor Shutdown to still be called for a prewarm task")
+		t.Fatal("expected executor Shutdown to still be called for a pull_only task")
 	}
 }
 
-func TestDestroyTaskPrewarmSkipsDelete(t *testing.T) {
+func TestDestroyTaskPullOnlySkipsDelete(t *testing.T) {
 	logger := hclog.NewNullLogger()
 	drv := NewTartDriver(logger).(*Driver)
 
 	mock := &mockVirtualizer{}
 	drv.client = mock
 
-	taskID := "task-prewarm-destroy"
+	taskID := "task-pull-only-destroy"
 	drv.tasks.Set(taskID, &taskHandle{
 		taskConfig: &drivers.TaskConfig{
 			ID:      taskID,
-			Name:    "test-prewarm-destroy",
-			AllocID: "alloc-prewarm-destroy",
+			Name:    "test-pull-only-destroy",
+			AllocID: "alloc-pull-only-destroy",
 		},
-		state:   drivers.TaskStateExited,
-		logger:  drv.logger,
-		prewarm: true,
+		state:    drivers.TaskStateExited,
+		logger:   drv.logger,
+		pullOnly: true,
 	})
 
 	if err := drv.DestroyTask(taskID, false); err != nil {
 		t.Fatalf("DestroyTask returned error: %v", err)
 	}
 	if mock.deleteCalled {
-		t.Fatal("expected virtualizer Delete to NOT be called for a prewarm task")
+		t.Fatal("expected virtualizer Delete to NOT be called for a pull_only task")
 	}
 	if _, ok := drv.tasks.Get(taskID); ok {
 		t.Fatalf("expected task %q to be removed from store", taskID)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -41,6 +41,10 @@ func (m *mockVirtualizer) BuildStartArgs(VMConfig) ([]string, error)            
 func (m *mockVirtualizer) NeedsImageDownload(context.Context, VMConfig) (bool, error) {
 	return false, nil
 }
+func (m *mockVirtualizer) PrepareRegistryEnv(context.Context, VMConfig) ([]string, error) {
+	return nil, nil
+}
+func (m *mockVirtualizer) BuildPrewarmArgs(VMConfig) []string { return nil }
 
 type stubExecutor struct {
 	shutdownCalled bool
@@ -113,6 +117,75 @@ func TestStopTaskDeletesVM(t *testing.T) {
 
 	if !mock.deleteCalled || mock.deleteName != expectedName {
 		t.Fatalf("expected Delete to be called with %q", expectedName)
+	}
+}
+
+func TestStopTaskPrewarmSkipsVMOps(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	drv := NewTartDriver(logger).(*Driver)
+
+	mock := &mockVirtualizer{}
+	drv.client = mock
+
+	exec := &stubExecutor{}
+	doneCh := make(chan struct{})
+	close(doneCh)
+
+	taskID := "task-prewarm-stop"
+	drv.tasks.Set(taskID, &taskHandle{
+		taskConfig: &drivers.TaskConfig{
+			ID:      taskID,
+			Name:    "test-prewarm-stop",
+			AllocID: "alloc-prewarm-stop",
+		},
+		state:   drivers.TaskStateRunning,
+		exec:    exec,
+		doneCh:  doneCh,
+		logger:  drv.logger,
+		prewarm: true,
+	})
+
+	if err := drv.StopTask(taskID, time.Second, "SIGINT"); err != nil {
+		t.Fatalf("StopTask returned error: %v", err)
+	}
+	if mock.stopCalled {
+		t.Fatal("expected virtualizer Stop to NOT be called for a prewarm task")
+	}
+	if mock.deleteCalled {
+		t.Fatal("expected virtualizer Delete to NOT be called for a prewarm task")
+	}
+	if !exec.shutdownCalled {
+		t.Fatal("expected executor Shutdown to still be called for a prewarm task")
+	}
+}
+
+func TestDestroyTaskPrewarmSkipsDelete(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	drv := NewTartDriver(logger).(*Driver)
+
+	mock := &mockVirtualizer{}
+	drv.client = mock
+
+	taskID := "task-prewarm-destroy"
+	drv.tasks.Set(taskID, &taskHandle{
+		taskConfig: &drivers.TaskConfig{
+			ID:      taskID,
+			Name:    "test-prewarm-destroy",
+			AllocID: "alloc-prewarm-destroy",
+		},
+		state:   drivers.TaskStateExited,
+		logger:  drv.logger,
+		prewarm: true,
+	})
+
+	if err := drv.DestroyTask(taskID, false); err != nil {
+		t.Fatalf("DestroyTask returned error: %v", err)
+	}
+	if mock.deleteCalled {
+		t.Fatal("expected virtualizer Delete to NOT be called for a prewarm task")
+	}
+	if _, ok := drv.tasks.Get(taskID); ok {
+		t.Fatalf("expected task %q to be removed from store", taskID)
 	}
 }
 

--- a/driver/handle.go
+++ b/driver/handle.go
@@ -50,9 +50,9 @@ type taskHandle struct {
 	// doneCh is closed when the task has finished executing
 	doneCh chan struct{}
 
-	// prewarm indicates this task is a short-lived image prefetch; the
+	// pullOnly indicates this task is a short-lived image prefetch; the
 	// driver must skip VM-lifecycle operations (run/stop/delete) for it.
-	prewarm bool
+	pullOnly bool
 }
 
 // TaskStatus returns the current status of the task

--- a/driver/handle.go
+++ b/driver/handle.go
@@ -49,6 +49,10 @@ type taskHandle struct {
 
 	// doneCh is closed when the task has finished executing
 	doneCh chan struct{}
+
+	// prewarm indicates this task is a short-lived image prefetch; the
+	// driver must skip VM-lifecycle operations (run/stop/delete) for it.
+	prewarm bool
 }
 
 // TaskStatus returns the current status of the task

--- a/driver/tart_client.go
+++ b/driver/tart_client.go
@@ -61,35 +61,51 @@ func (c *TartClient) Available(ctx context.Context) (string, error) {
 	return version, nil
 }
 
-// SetupVM creates a new Tart VM from a URL
-func (c *TartClient) Setup(ctx context.Context, config VMConfig) (string, error) {
-	// Prepare environment for tart commands. Include task-specific
-	// variables so auth credentials are available during
-	// image pulls.
+// PrepareRegistryEnv builds the environment slice passed to tart commands
+// and performs a `tart login` against the target registry when task-level
+// auth credentials are configured. The resulting environment is suitable for
+// reuse across subsequent tart invocations (clone, pull, etc.).
+func (c *TartClient) PrepareRegistryEnv(ctx context.Context, config VMConfig) ([]string, error) {
 	env := os.Environ()
 	if config.NomadConfig != nil {
 		env = append(env, config.NomadConfig.EnvList()...)
 	}
 
-	// Prefer credentials from task config; otherwise rely on env variables.
-	// Always pass through the environment to tart commands.
-	if config.TaskConfig.Auth.IsValid() {
-		host, err := registryHost(config.TaskConfig.URL)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse URL: %v", err)
-		}
-		loginCmd := execCommandContext(ctx, "tart", "login", host, "--username", config.TaskConfig.Auth.Username, "--password-stdin")
-		loginCmd.Stdin = strings.NewReader(config.TaskConfig.Auth.Password)
-		loginCmd.Env = env
-
-		var stderr bytes.Buffer
-		loginCmd.Stderr = &stderr
-
-		if err := loginCmd.Run(); err != nil {
-			return "", fmt.Errorf("failed to login to container registry: %v (stderr: %s)", err, stderr.String())
-		}
-	} else {
+	if !config.TaskConfig.Auth.IsValid() {
 		c.logger.Trace("Auth not provided; relying on env vars for registry access")
+		return env, nil
+	}
+
+	host, err := registryHost(config.TaskConfig.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %v", err)
+	}
+
+	loginCmd := execCommandContext(ctx, "tart", "login", host, "--username", config.TaskConfig.Auth.Username, "--password-stdin")
+	loginCmd.Stdin = strings.NewReader(config.TaskConfig.Auth.Password)
+	loginCmd.Env = env
+
+	var stderr bytes.Buffer
+	loginCmd.Stderr = &stderr
+
+	if err := loginCmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to login to container registry: %v (stderr: %s)", err, stderr.String())
+	}
+
+	return env, nil
+}
+
+// BuildPrewarmArgs returns the tart CLI args used to prefetch an image into
+// the local OCI cache without creating a named VM.
+func (c *TartClient) BuildPrewarmArgs(config VMConfig) []string {
+	return []string{"pull", config.TaskConfig.URL}
+}
+
+// SetupVM creates a new Tart VM from a URL
+func (c *TartClient) Setup(ctx context.Context, config VMConfig) (string, error) {
+	env, err := c.PrepareRegistryEnv(ctx, config)
+	if err != nil {
+		return "", err
 	}
 
 	vmName := c.generateVMName(config.NomadConfig.AllocID)

--- a/driver/tart_client.go
+++ b/driver/tart_client.go
@@ -95,9 +95,9 @@ func (c *TartClient) PrepareRegistryEnv(ctx context.Context, config VMConfig) ([
 	return env, nil
 }
 
-// BuildPrewarmArgs returns the tart CLI args used to prefetch an image into
+// BuildPullArgs returns the tart CLI args used to prefetch an image into
 // the local OCI cache without creating a named VM.
-func (c *TartClient) BuildPrewarmArgs(config VMConfig) []string {
+func (c *TartClient) BuildPullArgs(config VMConfig) []string {
 	return []string{"pull", config.TaskConfig.URL}
 }
 

--- a/driver/tart_client_test.go
+++ b/driver/tart_client_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-func TestBuildPrewarmArgs(t *testing.T) {
+func TestBuildPullArgs(t *testing.T) {
 	c := NewTartClient(hclog.NewNullLogger())
 	url := "ghcr.io/cirruslabs/macos-sequoia-base:latest"
-	args := c.BuildPrewarmArgs(VMConfig{TaskConfig: TaskConfig{URL: url}})
+	args := c.BuildPullArgs(VMConfig{TaskConfig: TaskConfig{URL: url}})
 
 	if len(args) != 2 || args[0] != "pull" || args[1] != url {
-		t.Fatalf("unexpected prewarm args: %v", args)
+		t.Fatalf("unexpected pull args: %v", args)
 	}
 }
 

--- a/driver/tart_client_test.go
+++ b/driver/tart_client_test.go
@@ -1,6 +1,20 @@
 package driver
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func TestBuildPrewarmArgs(t *testing.T) {
+	c := NewTartClient(hclog.NewNullLogger())
+	url := "ghcr.io/cirruslabs/macos-sequoia-base:latest"
+	args := c.BuildPrewarmArgs(VMConfig{TaskConfig: TaskConfig{URL: url}})
+
+	if len(args) != 2 || args[0] != "pull" || args[1] != url {
+		t.Fatalf("unexpected prewarm args: %v", args)
+	}
+}
 
 func TestConvertTartStatus(t *testing.T) {
 	cases := map[string]VMState{

--- a/driver/virtualizer.go
+++ b/driver/virtualizer.go
@@ -89,12 +89,12 @@ type VirtualizationClient interface {
 	// PrepareRegistryEnv performs any registry authentication required to
 	// pull or clone the image referenced by the config and returns the
 	// environment slice that subsequent tart commands should inherit. It is
-	// intended to be called prior to Setup or prior to launching a prewarm
-	// pull via the executor.
+	// intended to be called prior to Setup or prior to launching a pull-only
+	// task via the executor.
 	PrepareRegistryEnv(ctx context.Context, config VMConfig) ([]string, error)
 
-	// BuildPrewarmArgs returns the CLI args for a prewarm (image prefetch)
-	// command that populates the local image cache without creating an
-	// allocation-specific VM.
-	BuildPrewarmArgs(config VMConfig) []string
+	// BuildPullArgs returns the CLI args for an image-only pull that
+	// populates the local image cache without creating an allocation-specific
+	// VM. Used by pull_only tasks.
+	BuildPullArgs(config VMConfig) []string
 }

--- a/driver/virtualizer.go
+++ b/driver/virtualizer.go
@@ -85,4 +85,16 @@ type VirtualizationClient interface {
 	// must be pulled/downloaded before Setup, allowing the caller to emit
 	// progress events appropriately.
 	NeedsImageDownload(ctx context.Context, config VMConfig) (bool, error)
+
+	// PrepareRegistryEnv performs any registry authentication required to
+	// pull or clone the image referenced by the config and returns the
+	// environment slice that subsequent tart commands should inherit. It is
+	// intended to be called prior to Setup or prior to launching a prewarm
+	// pull via the executor.
+	PrepareRegistryEnv(ctx context.Context, config VMConfig) ([]string, error)
+
+	// BuildPrewarmArgs returns the CLI args for a prewarm (image prefetch)
+	// command that populates the local image cache without creating an
+	// allocation-specific VM.
+	BuildPrewarmArgs(config VMConfig) []string
 }

--- a/examples/prewarm.nomad.hcl
+++ b/examples/prewarm.nomad.hcl
@@ -24,8 +24,8 @@ job "tart-prewarm-macos-sequoia" {
       driver = "tart"
 
       config {
-        url     = "ghcr.io/cirruslabs/macos-sequoia-base:latest"
-        prewarm = true
+        url       = "ghcr.io/cirruslabs/macos-sequoia-base:latest"
+        pull_only = true
 
         // auth is optional; only required for private registries.
         // auth {

--- a/examples/prewarm.nomad.hcl
+++ b/examples/prewarm.nomad.hcl
@@ -1,0 +1,43 @@
+// Pre-pull a Tart image onto selected Nomad clients so that subsequent
+// VM-running tasks can skip the registry download.
+//
+// This is a `sysbatch` job: Nomad runs it once per eligible client and the
+// allocation completes when `tart pull` exits. Re-running the job is safe;
+// tart will no-op when the image is already cached.
+//
+// Example:
+//   nomad job run examples/prewarm.nomad.hcl
+//   nomad job status tart-prewarm-macos-sequoia
+job "tart-prewarm-macos-sequoia" {
+  datacenters = ["dc1"]
+  type        = "sysbatch"
+
+  // Restrict to nodes that have the tart driver available. Add your own
+  // constraints (node class, hostname, etc.) to target specific clients.
+  constraint {
+    attribute = "${attr.driver.tart}"
+    value     = "1"
+  }
+
+  group "prewarm" {
+    task "pull" {
+      driver = "tart"
+
+      config {
+        url     = "ghcr.io/cirruslabs/macos-sequoia-base:latest"
+        prewarm = true
+
+        // auth is optional; only required for private registries.
+        // auth {
+        //   username = "..."
+        //   password = "..."
+        // }
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a "prewarm" boolean that will pull down the latest image from the given repo / tag.

Note that it uses `tart pull`, which always contacts the registry to get the latest tag. `tart clone` will only check for the existence of a tag on the machine, it won't check the registry to see if there's a new version.

## Testing

Verified it locally with a nomad agent and pulling down a sequoia image.