### PR TITLE
Extend TartEnvList PATH so child processes (softnet) can find /usr/bin tools

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -640,10 +640,15 @@ func (d *Driver) streamSyslogWithRetry(ctx context.Context, vmConfig VMConfig, s
 }
 
 func (d *Driver) TartEnvList(tc *drivers.TaskConfig) []string {
-	// Patch the env list to include the homebrew paths to help tart
-	// find other binaries (like softnet) as needed.
+	// Patch the env list to include the homebrew paths to help tart find
+	// other binaries (like softnet) as needed.
+	//
+	// /usr/bin must be included so softnet can locate sudo when it
+	// self-elevates: its Command::new("sudo") path lookup is restricted to
+	// PATH, and a sudo-less PATH causes the probe to fail before any sudoers
+	// check, surfacing as "passwordless sudo was not available".
 	list := tc.EnvList()
-	list = append(list, "PATH=/opt/homebrew/bin:/opt/homebrew/sbin")
+	list = append(list, "PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin")
 
 	return list
 }


### PR DESCRIPTION
## Summary

Extends the `PATH` that `nomad-driver-tart` sets on the tart subprocess to include `/usr/bin`, `/bin`, and other standard system bin paths in addition to the Homebrew paths.

## Why

When tart is invoked with `--net-softnet`/`--net-softnet-expose`, it spawns `softnet` as a child process. `softnet` inherits tart's environment, including `PATH`. When `softnet` is running as a non-root user, it self-elevates via `Command::new("sudo")` — which does a `PATH` lookup at execve time.

The driver's existing `PATH` was `/opt/homebrew/bin:/opt/homebrew/sbin`, which does not contain `sudo`. The `PATH` lookup fails, `Command::new("sudo").output()` returns `Err`, and softnet's `sudo_escalation_works()` returns false. softnet then exits with the misleading message:

```
root privileges are required to run and passwordless sudo was not available
```

…even when passwordless sudo IS available, just not reachable by softnet at that moment.

Adding `/usr/bin` (and friends) to the inherited `PATH` lets softnet find `sudo` and complete its self-elevation. Tested on a macOS bare-metal CI host running tart 2.32.1, softnet 0.18.0.

## Changes

- `driver/driver.go`: extend the `PATH` appended in `TartEnvList` from `/opt/homebrew/bin:/opt/homebrew/sbin` to `/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin`. Added a comment explaining the softnet-elevation interaction so future readers don't think the homebrew paths are sufficient.

## Test plan

- [x] \`mise run build\` succeeds
- [x] \`mise run vet\` succeeds
- [x] \`mise run test\` passes
- [x] Manual end-to-end: deployed the patched binary to a bare-metal host with an existing passwordless-sudo entry for softnet. Verified a tart task with \`softnet_expose = ["2222:22"]\` + \`softnet_allow = ["0.0.0.0/0"]\` boots successfully and accepts SSH connections forwarded through softnet. Without this change the same task fails at startup with "passwordless sudo was not available".