### PR TITLE
feat(networking): Add more complete support for Tart network modes

### DIFF
--- a/driver/client.go
+++ b/driver/client.go
@@ -72,7 +72,7 @@ type Commander interface {
 
 // Networker queries VM network info.
 type Networker interface {
-	IPAddress(ctx context.Context, vmName string) (string, error)
+	IPAddress(ctx context.Context, vmName string, network *NetworkConfig) (string, error)
 }
 
 // Builder constructs CLI arguments and environment for tart commands.

--- a/driver/config_network.go
+++ b/driver/config_network.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -16,6 +17,46 @@ type NetworkConfig struct {
 	SoftnetAllow []string `codec:"softnet_allow"`
 	// SoftnetExpose EXTERNAL:INTERNAL TCP port forward specs when using Softnet; implies Softnet
 	SoftnetExpose []string `codec:"softnet_expose"`
+}
+
+// appendNomadPortExposures returns a copy of cfg with Nomad-allocated port
+// mappings appended to Softnet expose rules. It only modifies configurations
+// explicitly using Softnet so that other Tart networking modes keep their
+// existing behavior.
+func appendNomadPortExposures(cfg *NetworkConfig, exposures []nomadPortExposure) *NetworkConfig {
+	if len(exposures) == 0 {
+		return cfg
+	}
+
+	copyCfg := &NetworkConfig{}
+	if cfg != nil {
+		*copyCfg = *cfg
+		copyCfg.SoftnetAllow = slices.Clone(cfg.SoftnetAllow)
+		copyCfg.SoftnetExpose = slices.Clone(cfg.SoftnetExpose)
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(copyCfg.Mode))
+	if mode != "softnet" {
+		return copyCfg
+	}
+
+	seen := make(map[string]struct{}, len(copyCfg.SoftnetExpose))
+	for _, expose := range copyCfg.SoftnetExpose {
+		seen[expose] = struct{}{}
+	}
+	for _, exposure := range exposures {
+		if exposure.HostPort <= 0 || exposure.GuestPort <= 0 {
+			continue
+		}
+		spec := fmt.Sprintf("%d:%d", exposure.HostPort, exposure.GuestPort)
+		if _, ok := seen[spec]; ok {
+			continue
+		}
+		copyCfg.SoftnetExpose = append(copyCfg.SoftnetExpose, spec)
+		seen[spec] = struct{}{}
+	}
+
+	return copyCfg
 }
 
 // buildTartNetworkArgs computes the appropriate tart networking flags from NetworkConfig.

--- a/driver/driver_env.go
+++ b/driver/driver_env.go
@@ -1,16 +1,35 @@
 package driver
 
 import (
+	"os"
+	"strings"
+
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
-func (d *Driver) tartEnvList(tc *drivers.TaskConfig) []string {
-	// Patch the env list to include the homebrew paths to help tart
-	// find other binaries (like softnet) as needed.
-	list := tc.EnvList()
-	list = append(list, "PATH=/opt/homebrew/bin:/opt/homebrew/sbin")
+const tartDefaultPath = "/opt/zerobrew/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
-	return list
+// tartEnvList ensures Tart can find helper binaries such as softnet while
+// preserving any PATH supplied by the task or inherited from the host.
+func tartEnvList(tc *drivers.TaskConfig) []string {
+	list := tc.EnvList()
+
+	pathValue := tartDefaultPath
+	if hostPath := os.Getenv("PATH"); hostPath != "" {
+		pathValue += ":" + hostPath
+	}
+
+	for i, env := range list {
+		if strings.HasPrefix(env, "PATH=") {
+			if current := strings.TrimPrefix(env, "PATH="); current != "" {
+				pathValue = tartDefaultPath + ":" + current
+			}
+			list[i] = "PATH=" + pathValue
+			return list
+		}
+	}
+
+	return append(list, "PATH="+pathValue)
 }
 
 func vmName(allocID string) string {

--- a/driver/driver_env_test.go
+++ b/driver/driver_env_test.go
@@ -1,0 +1,67 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+func TestTartEnvListIncludesSoftnetPath(t *testing.T) {
+	t.Setenv("PATH", "/custom/bin")
+	env := tartEnvList(&drivers.TaskConfig{})
+
+	var pathValue string
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "PATH=") {
+			pathValue = strings.TrimPrefix(entry, "PATH=")
+			break
+		}
+	}
+
+	if pathValue == "" {
+		t.Fatal("expected PATH in environment")
+	}
+	if !strings.Contains(pathValue, "/opt/zerobrew/bin") {
+		t.Fatalf("expected PATH to include /opt/zerobrew/bin, got %q", pathValue)
+	}
+	if !strings.Contains(pathValue, "/custom/bin") {
+		t.Fatalf("expected PATH to include inherited host PATH, got %q", pathValue)
+	}
+}
+
+func TestTartEnvListPreservesTaskPath(t *testing.T) {
+	tc := &drivers.TaskConfig{Env: map[string]string{"PATH": "/task/bin"}}
+	env := tartEnvList(tc)
+
+	var pathValue string
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "PATH=") {
+			pathValue = strings.TrimPrefix(entry, "PATH=")
+			break
+		}
+	}
+
+	if !strings.Contains(pathValue, "/task/bin") {
+		t.Fatalf("expected PATH to preserve task PATH, got %q", pathValue)
+	}
+	if !strings.Contains(pathValue, "/opt/zerobrew/bin") {
+		t.Fatalf("expected PATH to include softnet path, got %q", pathValue)
+	}
+}
+
+func TestTartEnvListDoesNotDependOnAmbientPath(t *testing.T) {
+	t.Setenv("PATH", "")
+	env := tartEnvList(&drivers.TaskConfig{})
+
+	var found bool
+	for _, entry := range env {
+		if entry == "PATH="+tartDefaultPath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected default PATH fallback, got %v", env)
+	}
+}

--- a/driver/driver_mock_test.go
+++ b/driver/driver_mock_test.go
@@ -86,7 +86,7 @@ type mockNetworker struct {
 	ipCalls int
 }
 
-func (m *mockNetworker) IPAddress(context.Context, string) (string, error) {
+func (m *mockNetworker) IPAddress(context.Context, string, *NetworkConfig) (string, error) {
 	m.ipCalls++
 	return m.ip, m.ipErr
 }

--- a/driver/driver_ssh.go
+++ b/driver/driver_ssh.go
@@ -12,23 +12,22 @@ import (
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
-// waitForSSH blocks until the VM reports an IP address, indicating SSH
-// should be reachable. Retries with exponential backoff from 1s to 10s.
-// Returns nil when ready, or ctx.Err() on cancellation.
-func (d *Driver) waitForSSH(ctx context.Context, vmConfig VMConfig) error {
+// waitForIPAddress blocks until the VM reports an IP address. Retries with
+// exponential backoff from 1s to 10s and returns the discovered address.
+func (d *Driver) waitForIPAddress(ctx context.Context, vmConfig VMConfig) (string, error) {
 	backoff := 1 * time.Second
 	maxBackoff := 10 * time.Second
 	name := vmName(vmConfig.Nomad.AllocID)
 
 	for {
-		ip, err := d.client.IPAddress(ctx, name)
+		ip, err := d.client.IPAddress(ctx, name, vmConfig.Driver.Network)
 		if err == nil && ip != "" {
-			return nil
+			return ip, nil
 		}
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return "", ctx.Err()
 		default:
 		}
 
@@ -40,6 +39,14 @@ func (d *Driver) waitForSSH(ctx context.Context, vmConfig VMConfig) error {
 			}
 		}
 	}
+}
+
+// waitForSSH blocks until the VM reports an IP address, indicating SSH
+// should be reachable. Retries with exponential backoff from 1s to 10s.
+// Returns nil when ready, or ctx.Err() on cancellation.
+func (d *Driver) waitForSSH(ctx context.Context, vmConfig VMConfig) error {
+	_, err := d.waitForIPAddress(ctx, vmConfig)
+	return err
 }
 
 // executeStartupCommand waits for SSH to become available, then runs the

--- a/driver/driver_task.go
+++ b/driver/driver_task.go
@@ -77,7 +77,7 @@ func (d *Driver) startPullOnlyTask(cfg *drivers.TaskConfig, vmConfig VMConfig, h
 	execCmd := &executor.ExecCommand{
 		Cmd:              "tart",
 		Args:             d.client.BuildPullArgs(vmConfig),
-		Env:              d.tartEnvList(cfg),
+		Env:              tartEnvList(cfg),
 		User:             cfg.User,
 		TaskDir:          cfg.TaskDir().Dir,
 		StdoutPath:       cfg.StdoutPath,
@@ -141,6 +141,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	}
 	vmConfig.Driver.Directories = resolveDirectoryMounts(cfg, vmConfig.Driver.Directories)
 	d.logger.Info("starting tart task", "task_cfg", hclog.Fmt("%+v", vmConfig.Driver))
+	if exposures := nomadPortExposures(cfg); len(exposures) > 0 {
+		d.logger.Debug("found Nomad allocated port mappings for Tart networking", "ports", hclog.Fmt("%+v", exposures))
+	}
 
 	if taskConfig.PullOnly {
 		return d.startPullOnlyTask(cfg, vmConfig, handle)
@@ -185,7 +188,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	execCmd := &executor.ExecCommand{
 		Cmd:              "tart",
 		Args:             args,
-		Env:              d.tartEnvList(cfg),
+		Env:              tartEnvList(cfg),
 		User:             cfg.User,
 		TaskDir:          cfg.TaskDir().Dir,
 		StdoutPath:       cfg.StdoutPath,

--- a/driver/driver_task.go
+++ b/driver/driver_task.go
@@ -32,6 +32,18 @@ func openTaskLog(path string) (*os.File, error) {
 	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 }
 
+func (d *Driver) resolveDriverNetwork(vmConfig VMConfig) (*drivers.DriverNetwork, error) {
+	ctx, cancel := context.WithTimeout(d.ctx, 45*time.Second)
+	defer cancel()
+
+	ip, err := d.waitForIPAddress(ctx, vmConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine VM IP for driver network override: %w", err)
+	}
+
+	return &drivers.DriverNetwork{IP: ip}, nil
+}
+
 func (d *Driver) emitTaskEvent(cfg *drivers.TaskConfig, msg string, annotations map[string]string) {
 	d.eventer.EmitEvent(&drivers.TaskEvent{
 		TaskID:      cfg.ID,
@@ -202,15 +214,21 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("failed to set driver state: %w", err)
 	}
 
+	networkOverride, err := d.resolveDriverNetwork(vmConfig)
+	if err != nil {
+		d.logger.Warn("failed to determine driver network override; continuing without one", "task_id", cfg.ID, "error", err)
+	}
+
 	h := &taskHandle{
-		exec:         execImpl,
-		pluginClient: pluginClient,
-		pid:          ps.Pid,
-		taskConfig:   cfg,
-		state:        drivers.TaskStateRunning,
-		startedAt:    time.Now(),
-		logger:       d.logger,
-		doneCh:       make(chan struct{}),
+		exec:            execImpl,
+		pluginClient:    pluginClient,
+		pid:             ps.Pid,
+		taskConfig:      cfg,
+		state:           drivers.TaskStateRunning,
+		startedAt:       time.Now(),
+		logger:          d.logger,
+		doneCh:          make(chan struct{}),
+		networkOverride: networkOverride.Copy(),
 	}
 
 	stdoutFile, err := openTaskLog(cfg.StdoutPath)
@@ -245,7 +263,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	go h.run()
 
 	// Return a driver handle
-	return handle, nil, nil
+	return handle, networkOverride.Copy(), nil
 }
 
 // RecoverTask recreates the in-memory state of a task from a TaskHandle.

--- a/driver/handle.go
+++ b/driver/handle.go
@@ -90,6 +90,10 @@ type taskHandle struct {
 	// pullOnly indicates this task is a short-lived image prefetch; the
 	// driver must skip VM-lifecycle operations (run/stop/delete) for it.
 	pullOnly bool
+
+	// networkOverride is the driver-provided network metadata used by
+	// Nomad service registrations with address_mode = "driver".
+	networkOverride *drivers.DriverNetwork
 }
 
 // TaskStatus returns the current status of the task
@@ -97,13 +101,20 @@ func (h *taskHandle) TaskStatus() *drivers.TaskStatus {
 	h.stateLock.RLock()
 	defer h.stateLock.RUnlock()
 
+	var exitResult *drivers.ExitResult
+	if h.exitResult != nil {
+		copy := *h.exitResult
+		exitResult = &copy
+	}
+
 	status := &drivers.TaskStatus{
-		ID:          h.taskConfig.ID,
-		Name:        h.taskConfig.Name,
-		State:       h.state,
-		StartedAt:   h.startedAt,
-		CompletedAt: h.completedAt,
-		ExitResult:  h.exitResult,
+		ID:              h.taskConfig.ID,
+		Name:            h.taskConfig.Name,
+		State:           h.state,
+		StartedAt:       h.startedAt,
+		CompletedAt:     h.completedAt,
+		ExitResult:      exitResult,
+		NetworkOverride: h.networkOverride.Copy(),
 		DriverAttributes: map[string]string{
 			// No custom attributes for now, but something like the task PID could be useful.
 			"pid": strconv.Itoa(h.pid),

--- a/driver/network_override_test.go
+++ b/driver/network_override_test.go
@@ -1,0 +1,67 @@
+package driver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+func TestResolveDriverNetworkReturnsVMIP(t *testing.T) {
+	mock := &testClient{mockNetworker: mockNetworker{ip: "192.168.64.10"}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	drv := &Driver{ctx: ctx, client: mock, logger: hclog.NewNullLogger()}
+	vm := VMConfig{Nomad: &drivers.TaskConfig{AllocID: "alloc-network"}}
+
+	network, err := drv.resolveDriverNetwork(vm)
+	if err != nil {
+		t.Fatalf("resolveDriverNetwork returned error: %v", err)
+	}
+	if network == nil {
+		t.Fatal("expected network override")
+	}
+	if network.IP != "192.168.64.10" {
+		t.Fatalf("expected IP 192.168.64.10, got %q", network.IP)
+	}
+	if network.AutoAdvertise {
+		t.Fatal("expected AutoAdvertise to be false")
+	}
+}
+
+func TestTaskStatusIncludesNetworkOverride(t *testing.T) {
+	h := &taskHandle{
+		taskConfig: &drivers.TaskConfig{ID: "task-1", Name: "vm"},
+		state:      drivers.TaskStateRunning,
+		startedAt:  time.Now(),
+		logger:     hclog.NewNullLogger(),
+		exitResult: &drivers.ExitResult{ExitCode: 7},
+		networkOverride: &drivers.DriverNetwork{
+			IP: "192.168.64.10",
+		},
+	}
+
+	status := h.TaskStatus()
+	if status.NetworkOverride == nil {
+		t.Fatal("expected NetworkOverride in task status")
+	}
+	if status.NetworkOverride.IP != "192.168.64.10" {
+		t.Fatalf("expected status network IP 192.168.64.10, got %q", status.NetworkOverride.IP)
+	}
+	if status.ExitResult == nil || status.ExitResult.ExitCode != 7 {
+		t.Fatalf("expected exit result copy with exit code 7, got %#v", status.ExitResult)
+	}
+
+	status.NetworkOverride.IP = "10.0.0.99"
+	status.ExitResult.ExitCode = 42
+
+	if h.networkOverride.IP != "192.168.64.10" {
+		t.Fatalf("expected handle network override to remain unchanged, got %q", h.networkOverride.IP)
+	}
+	if h.exitResult.ExitCode != 7 {
+		t.Fatalf("expected handle exit result to remain unchanged, got %d", h.exitResult.ExitCode)
+	}
+}

--- a/driver/networking_test.go
+++ b/driver/networking_test.go
@@ -87,6 +87,29 @@ func TestBuildTartNetworkArgs_SoftnetAllowAndExpose(t *testing.T) {
 	}
 }
 
+func TestAppendNomadPortExposures_Softnet(t *testing.T) {
+	cfg := &NetworkConfig{Mode: "softnet", SoftnetAllow: []string{"0.0.0.0/0"}}
+	got := appendNomadPortExposures(cfg, []nomadPortExposure{{Label: "http", HostPort: 21043, GuestPort: 8000}})
+	want := &NetworkConfig{Mode: "softnet", SoftnetAllow: []string{"0.0.0.0/0"}, SoftnetExpose: []string{"21043:8000"}}
+	if got == cfg {
+		t.Fatal("expected a copied config")
+	}
+	if !slices.Equal(got.SoftnetAllow, want.SoftnetAllow) || !slices.Equal(got.SoftnetExpose, want.SoftnetExpose) || got.Mode != want.Mode {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+	if len(cfg.SoftnetExpose) != 0 {
+		t.Fatalf("expected original config to be unchanged, got %#v", cfg)
+	}
+}
+
+func TestAppendNomadPortExposures_NonSoftnetNoop(t *testing.T) {
+	cfg := &NetworkConfig{Mode: "shared"}
+	got := appendNomadPortExposures(cfg, []nomadPortExposure{{HostPort: 21043, GuestPort: 8000}})
+	if got.Mode != "shared" || len(got.SoftnetExpose) != 0 {
+		t.Fatalf("unexpected config: %#v", got)
+	}
+}
+
 func TestBuildTartNetworkArgs_Conflicts(t *testing.T) {
 	cases := []*NetworkConfig{
 		{Mode: "host", BridgedInterface: "en0"},

--- a/driver/nomad_ports.go
+++ b/driver/nomad_ports.go
@@ -1,0 +1,41 @@
+package driver
+
+import (
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+// nomadPortExposure describes enough of Nomad's allocated port mapping for the
+// Tart driver to build host-to-guest forwarding rules in the future.
+type nomadPortExposure struct {
+	Label     string
+	HostPort  int
+	GuestPort int
+	HostIP    string
+}
+
+// nomadPortExposures extracts Nomad's allocated port mappings from the task
+// config. This is the data we would use to derive Tart softnet expose rules
+// with Docker-like UX.
+func nomadPortExposures(cfg *drivers.TaskConfig) []nomadPortExposure {
+	if cfg == nil || cfg.Resources == nil || cfg.Resources.Ports == nil {
+		return nil
+	}
+
+	ports := *cfg.Resources.Ports
+	out := make([]nomadPortExposure, 0, len(ports))
+	for _, port := range ports {
+		guestPort := port.To
+		if guestPort <= 0 {
+			guestPort = port.Value
+		}
+
+		out = append(out, nomadPortExposure{
+			Label:     port.Label,
+			HostPort:  port.Value,
+			GuestPort: guestPort,
+			HostIP:    port.HostIP,
+		})
+	}
+
+	return out
+}

--- a/driver/nomad_ports_test.go
+++ b/driver/nomad_ports_test.go
@@ -1,0 +1,51 @@
+package driver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+func TestNomadPortExposuresExtractsAllocatedMappings(t *testing.T) {
+	ports := structs.AllocatedPorts{
+		{Label: "http", Value: 21043, To: 4096, HostIP: "192.168.1.10"},
+		{Label: "ssh", Value: 22022, To: 22, HostIP: "192.168.1.10"},
+	}
+	cfg := &drivers.TaskConfig{
+		Resources: &drivers.Resources{
+			Ports: &ports,
+		},
+	}
+
+	got := nomadPortExposures(cfg)
+	want := []nomadPortExposure{
+		{Label: "http", HostPort: 21043, GuestPort: 4096, HostIP: "192.168.1.10"},
+		{Label: "ssh", HostPort: 22022, GuestPort: 22, HostIP: "192.168.1.10"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected exposures:\nwant: %#v\n got: %#v", want, got)
+	}
+}
+
+func TestNomadPortExposuresFallsBackToHostPortWhenToUnset(t *testing.T) {
+	ports := structs.AllocatedPorts{
+		{Label: "http", Value: 21043, To: 0, HostIP: "192.168.1.10"},
+	}
+	cfg := &drivers.TaskConfig{
+		Resources: &drivers.Resources{
+			Ports: &ports,
+		},
+	}
+
+	got := nomadPortExposures(cfg)
+	want := []nomadPortExposure{
+		{Label: "http", HostPort: 21043, GuestPort: 21043, HostIP: "192.168.1.10"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected exposures:\nwant: %#v\n got: %#v", want, got)
+	}
+}

--- a/driver/startup_command_test.go
+++ b/driver/startup_command_test.go
@@ -36,11 +36,11 @@ type testClient struct {
 	execCalls []execCall
 }
 
-func (m *testClient) IPAddress(ctx context.Context, vmName string) (string, error) {
+func (m *testClient) IPAddress(ctx context.Context, vmName string, network *NetworkConfig) (string, error) {
 	if m.ipAddrFn != nil {
 		return m.ipAddrFn(ctx, vmName)
 	}
-	return m.mockNetworker.IPAddress(ctx, vmName)
+	return m.mockNetworker.IPAddress(ctx, vmName, network)
 }
 
 func (m *testClient) Exec(ctx context.Context, c VMConfig, opts ExecOptions) (int, error) {

--- a/driver/tart_client_exec.go
+++ b/driver/tart_client_exec.go
@@ -27,7 +27,7 @@ func (c *tartCLI) Exec(ctx context.Context, config VMConfig, opts ExecOptions) (
 
 	vmName := vmName(config.Nomad.AllocID)
 
-	ip, err := c.IPAddress(ctx, vmName)
+	ip, err := c.IPAddress(ctx, vmName, config.Driver.Network)
 	if err != nil || ip == "" {
 		return -1, fmt.Errorf("%w: %v", errVMIPUnavailable, err)
 	}

--- a/driver/tart_client_lifecycle.go
+++ b/driver/tart_client_lifecycle.go
@@ -126,9 +126,17 @@ func (c *tartCLI) Delete(ctx context.Context, vmName string) error {
 	return nil
 }
 
-// IPAddress returns the IP address of a running VM
-func (c *tartCLI) IPAddress(ctx context.Context, vmName string) (string, error) {
-	cmd := exec.CommandContext(ctx, "tart", "ip", vmName)
+// IPAddress returns the IP address of a running VM.
+// Bridged networking requires ARP-based resolution because Tart cannot rely on
+// the host DHCP lease database in that mode.
+func (c *tartCLI) IPAddress(ctx context.Context, vmName string, network *NetworkConfig) (string, error) {
+	args := []string{"ip"}
+	if network != nil && strings.EqualFold(strings.TrimSpace(network.Mode), "bridged") {
+		args = append(args, "--resolver=arp")
+	}
+	args = append(args, vmName)
+
+	cmd := c.runner.Run(ctx, "tart", args...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/driver/tart_client_registry.go
+++ b/driver/tart_client_registry.go
@@ -70,7 +70,9 @@ func (c *tartCLI) BuildStartArgs(config VMConfig) ([]string, error) {
 		}
 	}
 
-	netArgs, err := buildTartNetworkArgs(config.Driver.Network)
+	networkCfg := appendNomadPortExposures(config.Driver.Network, nomadPortExposures(config.Nomad))
+
+	netArgs, err := buildTartNetworkArgs(networkCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/tart_client_test.go
+++ b/driver/tart_client_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
 type recordingRunner struct {
@@ -16,6 +18,18 @@ type recordingRunner struct {
 	stdout string
 	stderr string
 	exit   int
+}
+
+func slicesContainSequence(haystack, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if reflect.DeepEqual(haystack[i:i+len(needle)], needle) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *recordingRunner) Run(ctx context.Context, name string, args ...string) *exec.Cmd {
@@ -104,5 +118,32 @@ func TestIPAddressUsesARPResolverForBridgedNetworking(t *testing.T) {
 	wantArgs := []string{"ip", "--resolver=arp", "vm-bridge"}
 	if !reflect.DeepEqual(r.args, wantArgs) {
 		t.Fatalf("unexpected args: want %v got %v", wantArgs, r.args)
+	}
+}
+
+func TestBuildStartArgsAddsSoftnetExposeFromNomadPorts(t *testing.T) {
+	c := &tartCLI{logger: hclog.NewNullLogger(), runner: &recordingRunner{}}
+	ports := structs.AllocatedPorts{{Label: "http", Value: 21043, To: 8000, HostIP: "192.168.1.10"}}
+	cfg := VMConfig{
+		Driver: TaskConfig{
+			Network: &NetworkConfig{Mode: "softnet", SoftnetAllow: []string{"0.0.0.0/0"}},
+		},
+		Nomad: &drivers.TaskConfig{
+			AllocID: "alloc-1",
+			Resources: &drivers.Resources{
+				Ports: &ports,
+			},
+		},
+	}
+
+	args, err := c.BuildStartArgs(cfg)
+	if err != nil {
+		t.Fatalf("BuildStartArgs returned error: %v", err)
+	}
+	if !reflect.DeepEqual(args[:3], []string{"run", "nomad-alloc-1", "--no-graphics"}) {
+		t.Fatalf("unexpected leading args: %v", args)
+	}
+	if !slicesContainSequence(args, []string{"--net-softnet", "--net-softnet-allow", "0.0.0.0/0", "--net-softnet-expose", "21043:8000"}) {
+		t.Fatalf("expected softnet expose args in %v", args)
 	}
 }

--- a/driver/tart_client_test.go
+++ b/driver/tart_client_test.go
@@ -1,10 +1,35 @@
 package driver
 
 import (
+	"context"
+	"os/exec"
+	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
 )
+
+type recordingRunner struct {
+	name   string
+	args   []string
+	stdout string
+	stderr string
+	exit   int
+}
+
+func (r *recordingRunner) Run(ctx context.Context, name string, args ...string) *exec.Cmd {
+	r.name = name
+	r.args = append([]string(nil), args...)
+	script := "printf '%s' \"$TART_TEST_STDOUT\"; printf '%s' \"$TART_TEST_STDERR\" >&2; exit \"$TART_TEST_EXIT\""
+	cmd := exec.CommandContext(ctx, "sh", "-c", script)
+	cmd.Env = append(cmd.Environ(),
+		"TART_TEST_STDOUT="+r.stdout,
+		"TART_TEST_STDERR="+r.stderr,
+		"TART_TEST_EXIT="+strconv.Itoa(r.exit),
+	)
+	return cmd
+}
 
 func TestBuildPullArgs(t *testing.T) {
 	c := NewTartClient(hclog.NewNullLogger())
@@ -42,5 +67,42 @@ func TestShellQuoteCommand(t *testing.T) {
 	want := "'/bin/bash' '/Volumes/My Shared Files/alloc/startup.sh' 'O'\\''Hare'"
 	if got != want {
 		t.Fatalf("unexpected quoted command:\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestIPAddressUsesDefaultResolverForNonBridgedNetworking(t *testing.T) {
+	r := &recordingRunner{stdout: "192.168.64.10\n"}
+	c := &tartCLI{logger: hclog.NewNullLogger(), runner: r}
+
+	ip, err := c.IPAddress(context.Background(), "vm-1", &NetworkConfig{Mode: "shared"})
+	if err != nil {
+		t.Fatalf("IPAddress returned error: %v", err)
+	}
+	if ip != "192.168.64.10" {
+		t.Fatalf("expected IP 192.168.64.10, got %q", ip)
+	}
+	if r.name != "tart" {
+		t.Fatalf("expected tart command, got %q", r.name)
+	}
+	wantArgs := []string{"ip", "vm-1"}
+	if !reflect.DeepEqual(r.args, wantArgs) {
+		t.Fatalf("unexpected args: want %v got %v", wantArgs, r.args)
+	}
+}
+
+func TestIPAddressUsesARPResolverForBridgedNetworking(t *testing.T) {
+	r := &recordingRunner{stdout: "10.0.0.55\n"}
+	c := &tartCLI{logger: hclog.NewNullLogger(), runner: r}
+
+	ip, err := c.IPAddress(context.Background(), "vm-bridge", &NetworkConfig{Mode: "bridged"})
+	if err != nil {
+		t.Fatalf("IPAddress returned error: %v", err)
+	}
+	if ip != "10.0.0.55" {
+		t.Fatalf("expected IP 10.0.0.55, got %q", ip)
+	}
+	wantArgs := []string{"ip", "--resolver=arp", "vm-bridge"}
+	if !reflect.DeepEqual(r.args, wantArgs) {
+		t.Fatalf("unexpected args: want %v got %v", wantArgs, r.args)
 	}
 }

--- a/examples/opencode-server.nomad.hcl
+++ b/examples/opencode-server.nomad.hcl
@@ -1,0 +1,142 @@
+job "opencode-server" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  // Register this as a parameterized batch job. `nomad job run` only registers
+  // the parent job; each VM starts when you dispatch it:
+  //   nomad job dispatch opencode-server
+  parameterized {
+    payload = "forbidden"
+  }
+
+  group "servers" {
+    count = 1
+
+    // Virtualization.framework mandates a maximum of 2 VMs per host.
+    constraint {
+      attribute = attr.driver.tart.available_slots
+      value     = "true"
+    }
+
+    task "vm" {
+      driver = "tart"
+
+      service {
+        // Keep the service name static. Nomad does not interpolate allocation
+        // runtime environment variables such as NOMAD_ALLOC_ID in this parent
+        // parameterized job's service listing. Each dispatched allocation is
+        // still a distinct service instance with its own AllocID, JobID,
+        // address, and port in Nomad service discovery.
+        name         = "opencode"
+        provider     = "nomad"
+        address_mode = "driver"
+        port         = "4096"
+
+        tags = ["opencode-server"]
+      }
+
+      // Set these strings directly for your environment.
+      env {
+        SSH_PASSWORD             = "admin"
+        OPENCODE_HOSTNAME        = "0.0.0.0"
+        OPENCODE_PORT            = "4096"
+        OPENCODE_SERVER_USERNAME = "admin"
+        OPENCODE_SERVER_PASSWORD = "change-me"
+        ANTHROPIC_API_KEY        = ""
+        OPENAI_API_KEY           = ""
+        GITHUB_TOKEN             = ""
+      }
+
+      template {
+        data        = <<EOH
+SSH_PASSWORD={{ env "SSH_PASSWORD" }}
+OPENCODE_HOSTNAME={{ env "OPENCODE_HOSTNAME" }}
+OPENCODE_PORT={{ env "OPENCODE_PORT" }}
+OPENCODE_SERVER_USERNAME={{ env "OPENCODE_SERVER_USERNAME" }}
+OPENCODE_SERVER_PASSWORD={{ env "OPENCODE_SERVER_PASSWORD" }}
+ANTHROPIC_API_KEY={{ env "ANTHROPIC_API_KEY" }}
+OPENAI_API_KEY={{ env "OPENAI_API_KEY" }}
+GITHUB_TOKEN={{ env "GITHUB_TOKEN" }}
+EOH
+        destination = "secrets/opencode.env"
+        env         = true
+      }
+
+      template {
+        data = <<EOF
+#!/bin/bash
+set -euo pipefail
+
+SECRETS_FILE="/Volumes/My Shared Files/secrets/opencode.env"
+if [[ -f "$SECRETS_FILE" ]]; then
+  set -a
+  source "$SECRETS_FILE"
+  set +a
+fi
+
+export PATH="$HOME/.opencode/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+WORK_DIR="$HOME/opencode-workspace"
+mkdir -p "$WORK_DIR"
+cd "$WORK_DIR"
+
+echo "opencode: startup begin $(date -u +%FT%TZ)"
+echo "opencode: installing CLI if needed"
+if ! command -v opencode >/dev/null 2>&1; then
+  curl -fsSL https://opencode.ai/install | bash
+  export PATH="$HOME/.opencode/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+fi
+
+OPENCODE_BIN="$(command -v opencode || true)"
+if [[ -z "$OPENCODE_BIN" ]]; then
+  echo "opencode: opencode binary not found on PATH=$PATH"
+  exit 1
+fi
+
+echo "opencode: version"
+"$OPENCODE_BIN" --version || true
+
+VM_IP="$(ipconfig getifaddr en0 2>/dev/null || true)"
+if [[ -n "$VM_IP" ]]; then
+  echo "opencode: VM IP is $VM_IP"
+  echo "opencode: from the Nomad client, try http://$VM_IP:$${OPENCODE_PORT:-4096}"
+fi
+
+echo "opencode: serving $WORK_DIR on $${OPENCODE_HOSTNAME:-0.0.0.0}:$${OPENCODE_PORT:-4096}"
+exec "$OPENCODE_BIN" serve --hostname "$${OPENCODE_HOSTNAME:-0.0.0.0}" --port "$${OPENCODE_PORT:-4096}"
+EOF
+        destination = "local/start-opencode.sh"
+        perms       = "755"
+      }
+
+      config {
+        url          = "ghcr.io/cirruslabs/macos-sequoia-base:latest"
+        ssh_user     = "admin"
+        ssh_password = "${SSH_PASSWORD}"
+        show_ui      = false
+
+        // No network block: use Tart's default shared/NAT networking.
+        // The driver uses this to SSH into the VM and run the startup script.
+        // The startup script logs the guest IP; from the Nomad client, open:
+        //   http://<guest-ip>:4096
+
+        command = "/bin/bash"
+        args    = ["/Volumes/My Shared Files/local/start-opencode.sh"]
+
+        directory {
+          name = "local"
+          path = "${NOMAD_TASK_DIR}"
+        }
+      }
+
+      resources {
+        cores  = 8
+        memory = 10240
+      }
+
+      logs {
+        max_files     = 5
+        max_file_size = 10
+      }
+    }
+  }
+}

--- a/examples/opencode-server.nomad.hcl
+++ b/examples/opencode-server.nomad.hcl
@@ -18,6 +18,12 @@ job "opencode-server" {
       value     = "true"
     }
 
+    network {
+      port "http" {
+        to = 4096
+      }
+    }
+
     task "vm" {
       driver = "tart"
 
@@ -29,8 +35,8 @@ job "opencode-server" {
         // address, and port in Nomad service discovery.
         name         = "opencode"
         provider     = "nomad"
-        address_mode = "driver"
-        port         = "4096"
+        address_mode = "host"
+        port         = "http"
 
         tags = ["opencode-server"]
       }
@@ -114,10 +120,14 @@ EOF
         ssh_password = "${SSH_PASSWORD}"
         show_ui      = false
 
-        // No network block: use Tart's default shared/NAT networking.
-        // The driver uses this to SSH into the VM and run the startup script.
-        // The startup script logs the guest IP; from the Nomad client, open:
-        //   http://<guest-ip>:4096
+        // Softnet lets the driver map Nomad's allocated host port for the
+        // "http" label to the guest service listening on port 4096.
+        // With address_mode = "host", discover the service via the Nomad
+        // service registration rather than the guest IP.
+        network {
+          mode          = "softnet"
+          softnet_allow = ["0.0.0.0/0"]
+        }
 
         command = "/bin/bash"
         args    = ["/Volumes/My Shared Files/local/start-opencode.sh"]

--- a/examples/python-fileserver.nomad.hcl
+++ b/examples/python-fileserver.nomad.hcl
@@ -1,0 +1,85 @@
+job "python-fileserver" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  update {
+    max_parallel      = 0
+    healthy_deadline  = "30m"
+    progress_deadline = "60m"
+  }
+
+  group "servers" {
+    count = 1
+
+    constraint {
+      attribute = attr.driver.tart.available_slots
+      value     = "true"
+    }
+
+    network {
+      port "http" {
+        to = 8000
+      }
+    }
+
+    task "vm" {
+      driver = "tart"
+
+      service {
+        name         = "python-fileserver"
+        provider     = "nomad"
+        port         = "http"
+        address_mode = "host"
+
+        tags = ["tart", "python", "fileserver"]
+      }
+
+      template {
+        data = <<EOF
+#!/bin/bash
+set -euo pipefail
+
+cd "$HOME"
+
+echo "fileserver: startup begin $(date -u +%FT%TZ)"
+echo "fileserver: serving $HOME on 0.0.0.0:8000"
+exec python3 -m http.server 8000 --bind 0.0.0.0 --directory "$HOME"
+EOF
+        destination = "local/start-fileserver.sh"
+        perms       = "755"
+      }
+
+      config {
+        url          = "ghcr.io/cirruslabs/macos-sequoia-base:latest"
+        ssh_user     = "admin"
+        ssh_password = "admin"
+        show_ui      = false
+
+        // Softnet is the mode that can eventually expose Nomad-allocated
+        // host ports via Tart's --net-softnet-expose behavior.
+        network {
+          mode          = "softnet"
+          softnet_allow = ["0.0.0.0/0"]
+        }
+
+        command = "/bin/bash"
+        args    = ["/Volumes/My Shared Files/local/start-fileserver.sh"]
+
+        directory {
+          name = "local"
+          path = "${NOMAD_TASK_DIR}"
+        }
+      }
+
+      resources {
+        cores  = 4
+        memory = 8192
+      }
+
+      logs {
+        max_files     = 5
+        max_file_size = 10
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add Tart driver network override support and wire Nomad-allocated ports into Tart Softnet exposure so Tart-backed services can be advertised and reached more like Docker-backed Nomad workloads.

This branch also adds example jobs and supporting tests around VM IP resolution, host-port exposure, and PATH handling for Softnet.

## What changed

### Driver networking / service registration
- Return a `DriverNetwork` override for running VM tasks once the VM IP is available
- Persist the network override on the in-memory task handle
- Include the network override in `TaskStatus`
- Return copies of mutable status fields (`DriverNetwork`, `ExitResult`) instead of exposing internal pointers

### Tart IP resolution
- Make IP resolution network-mode aware
- Use `tart ip --resolver=arp` for bridged networking
- Keep default `tart ip` behavior for non-bridged modes

### Softnet host port exposure
- Read Nomad allocated ports from `cfg.Resources.Ports`
- Extract label / host port / guest port (`to`) / host IP into a helper
- For `network.mode = "softnet"`, automatically append Nomad port mappings to Tart `--net-softnet-expose`
- Preserve any user-specified `softnet_expose` entries and avoid duplicates

### Tart runtime environment
- Fix the Tart subprocess PATH so helper binaries like `softnet` can be found
- Include `/opt/zerobrew/bin` plus standard system paths
- Preserve task-provided PATH and inherited host PATH

### Examples
- Add `examples/opencode-server.nomad.hcl`
  - uses Nomad `network` port allocation + `address_mode = "host"`
  - uses Tart Softnet to expose the guest service through the allocated host port
- Add `examples/python-fileserver.nomad.hcl`
  - simple VM that serves `$HOME` over `python3 -m http.server`
  - intended as a lightweight repro / validation job

## Why

Before this change:
- Tart-backed services could not reliably use `address_mode = "driver"`
- Nomad-allocated ports were visible to the driver but not translated into any real Tart port exposure
- Softnet could fail to launch under Nomad because the Tart subprocess PATH did not include the installed `softnet` binary

After this change:
- VM IPs can be returned to Nomad as driver network metadata
- Nomad port allocations can be turned into real Tart Softnet exposure rules
- Softnet-backed services can be advertised via host-mode service registration and reached through the allocated host port

## Testing

Added / updated tests for:
- network override resolution and status propagation
- bridged IP lookup behavior
- PATH construction for Tart subprocesses
- Nomad port extraction from `drivers.TaskConfig.Resources.Ports`
- Softnet expose arg generation from Nomad-allocated ports
- startup arg construction

Validated with:
- `go test ./driver`

## Reviewer callouts / caveats

- Softnet exposure is only auto-generated for tasks explicitly using `network.mode = "softnet"`
- Bridged IP lookup now depends on ARP-based resolution, matching Tart docs
- Tart/Softnet docs note that exposed ports may not be reachable from the host itself; testing may need to come from another machine on the network
- This is intentionally scoped to Tart Softnet exposure and does not try to implement a more general host-side proxy/forwarder
